### PR TITLE
Advance error handling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -205,6 +205,8 @@ type Backend struct {
 	Target string `mapstructure:"target"`
 	// name of the service discovery driver to use
 	SD string `mapstructure:"sd"`
+	// mandatory request, the error of which is returned instead of the answer
+	Required bool `mapstructure:"required"`
 
 	// list of keys to be replaced in the URLPattern
 	URLKeys []string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -204,7 +204,7 @@ func TestConfig_init(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	if hash != "08DTVE8Iwh1M8aRURBgk/rYcWc6BIwIgW/BflQo1OnE=" {
+	if hash != "hw/7+GhUYAoHyvJsDyexp0wWwvf2tRbAZQhkSEsfuE8=" {
 		t.Errorf("unexpected hash: %s", hash)
 	}
 }

--- a/config/parser.go
+++ b/config/parser.go
@@ -241,6 +241,7 @@ type parseableBackend struct {
 	Mapping                  map[string]string `json:"mapping"`
 	Encoding                 string            `json:"encoding"`
 	IsCollection             bool              `json:"is_collection"`
+	Required                 bool              `json:"required"`
 	Target                   string            `json:"target"`
 	ExtraConfig              *ExtraConfig      `json:"extra_config,omitempty"`
 	SD                       string            `json:"sd"`
@@ -258,6 +259,7 @@ func (p *parseableBackend) normalize() *Backend {
 		Mapping:                  p.Mapping,
 		Encoding:                 p.Encoding,
 		IsCollection:             p.IsCollection,
+		Required:                 p.Required,
 		Target:                   p.Target,
 		SD:                       p.SD,
 	}

--- a/proxy/http.go
+++ b/proxy/http.go
@@ -39,6 +39,10 @@ func NewHTTPProxyWithHTTPExecutor(remote *config.Backend, re client.HTTPRequestE
 
 	ef := NewEntityFormatter(remote)
 	rp := DefaultHTTPResponseParserFactory(HTTPResponseParserConfig{dec, ef})
+	if remote.Required {
+		rp = HTTPResponseWithErrorParserFactory(HTTPResponseParserConfig{dec, ef})
+		return NewHTTPProxyDetailed(remote, re, client.NoOpHTTPStatusHandler, rp)
+	}
 	return NewHTTPProxyDetailed(remote, re, client.GetHTTPStatusHandler(remote), rp)
 }
 

--- a/proxy/http_response_test.go
+++ b/proxy/http_response_test.go
@@ -38,3 +38,72 @@ func TestNopHTTPResponseParser(t *testing.T) {
 		t.Error("unexpected result")
 	}
 }
+
+func TestHTTPResponseWithErrorParserFactory(t *testing.T) {
+	type args struct {
+		cfg        HTTPResponseParserConfig
+		statusCode int
+	}
+	tests := []struct {
+		name           string
+		args           args
+		wantMetaData   Metadata
+		wantStatusCode int
+		wantIsComplete bool
+	}{
+		{
+			name: "success bad status",
+			args: args{
+				cfg:        DefaultHTTPResponseParserConfig,
+				statusCode: http.StatusBadGateway,
+			},
+			wantMetaData: Metadata{
+				StatusCode: 0,
+				IsRequired: true,
+			},
+			wantIsComplete: false,
+			wantStatusCode: http.StatusBadGateway,
+		},
+		{
+			name: "success status ok",
+			args: args{
+				cfg:        DefaultHTTPResponseParserConfig,
+				statusCode: http.StatusOK,
+			},
+			wantMetaData: Metadata{
+				StatusCode: 0,
+				IsRequired: false,
+			},
+			wantIsComplete: true,
+			wantStatusCode: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			w := httptest.NewRecorder()
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("header1", "value1")
+				w.WriteHeader(tt.args.statusCode)
+				w.Write([]byte("some text"))
+			}
+			req, _ := http.NewRequest("GET", "/url", nil)
+			handler(w, req)
+
+			parser := HTTPResponseWithErrorParserFactory(tt.args.cfg)
+			resp, err := parser(ctx, w.Result())
+			if err != nil {
+				t.Error("unexpected error:", err.Error())
+			}
+			if resp.Metadata.IsRequired != tt.wantMetaData.IsRequired {
+				t.Error("unexpected result")
+			}
+			if resp.Metadata.StatusCode != tt.wantStatusCode {
+				t.Error("unexpected status code")
+			}
+			if resp.IsComplete != tt.wantIsComplete {
+				t.Error("unexpected status code")
+			}
+		})
+	}
+}

--- a/proxy/merging.go
+++ b/proxy/merging.go
@@ -293,6 +293,12 @@ func combineData(total int, parts []*Response) *Response {
 			isComplete = false
 			continue
 		}
+		if part.Metadata.IsRequired && part.Metadata.StatusCode >= 400 {
+			// return the first error encountered
+			retResponse = part
+			retResponse.IsComplete = false
+			return retResponse
+		}
 		isComplete = isComplete && part.IsComplete
 		if retResponse == nil {
 			retResponse = part

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,4 +1,4 @@
-//Package proxy provides proxy and proxy middleware interfaces and implementations.
+// Package proxy provides proxy and proxy middleware interfaces and implementations.
 package proxy
 
 import (
@@ -16,6 +16,7 @@ const Namespace = "github.com/devopsfaith/krakend/proxy"
 type Metadata struct {
 	Headers    map[string][]string
 	StatusCode int
+	IsRequired bool
 }
 
 // Response is the entity returned by the proxy

--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -54,6 +54,8 @@ func CustomErrorEndpointHandler(configuration *config.EndpointConfig, prxy proxy
 				if isCacheEnabled {
 					c.Header("Cache-Control", cacheControlHeaderValue)
 				}
+			} else if response.Metadata.IsRequired {
+				c.Status(response.Metadata.StatusCode)
 			}
 
 			for k, vs := range response.Metadata.Headers {

--- a/router/mux/render.go
+++ b/router/mux/render.go
@@ -71,6 +71,9 @@ func jsonRender(w http.ResponseWriter, response *proxy.Response) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	if response.Metadata.IsRequired && response.Metadata.StatusCode > 0 {
+		w.WriteHeader(response.Metadata.StatusCode)
+	}
 	w.Write(js)
 }
 
@@ -89,6 +92,9 @@ func stringRender(w http.ResponseWriter, response *proxy.Response) {
 	if !ok {
 		w.Write([]byte{})
 		return
+	}
+	if response.Metadata.IsRequired && response.Metadata.StatusCode > 0 {
+		w.WriteHeader(response.Metadata.StatusCode)
 	}
 	w.Write([]byte(msg))
 }

--- a/test/krakend.json
+++ b/test/krakend.json
@@ -356,6 +356,20 @@
                     "url_pattern": "/"
                 }
             ]
+        },
+        {
+            "endpoint": "/required_backend",
+            "backend": [
+                {
+                    "url_pattern": "/backend1",
+                    "host": [ "{{.b3}}" ]
+                },
+                {
+                    "url_pattern": "/backend2",
+                    "host": [ "{{.b12}}" ],
+                    "required": true
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Added property "required" for the backend request.
And if such a request to the backend did not succeed (the response code is greater than or equal to 400), the response of the endpoint crack point does not make sense. Therefore, the kraken immediately returns the response body of this unsuccessful request and its status code.
If there are several such unsuccessful requests, the first processed request is returned.

Implemented for the HTTP layer and only for parallel queries.

https://github.com/devopsfaith/krakend/issues/288