### PR TITLE
ignore the cfg name when extracting the hash

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -282,7 +282,8 @@ var (
 	defaultPort             = 8080
 )
 
-// Hash returns the sha 256 hash of the configuration in a standard base64 encoded string
+// Hash returns the sha 256 hash of the configuration in a standard base64 encoded string. It ignores the
+// name in order to reduce the noise.
 func (s *ServiceConfig) Hash() (string, error) {
 	var name string
 	name, s.Name = s.Name, ""

--- a/config/config.go
+++ b/config/config.go
@@ -284,6 +284,10 @@ var (
 
 // Hash returns the sha 256 hash of the configuration in a standard base64 encoded string
 func (s *ServiceConfig) Hash() (string, error) {
+	var name string
+	name, s.Name = s.Name, ""
+	defer func() { s.Name = name }()
+
 	b, err := json.Marshal(s)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
... in order to remove noise at the calculated hash