### PR TITLE
Add GlibcVersion variable to the core package to set the GLIBC used b…

### DIFF
--- a/core/version.go
+++ b/core/version.go
@@ -16,6 +16,9 @@ var KrakendVersion = "undefined"
 // GoVersion is the version of the go compiler used at build time
 var GoVersion = "undefined"
 
+// GlibcVersion is the version of the glibc used by CGO at build time
+var GlibcVersion = "undefined"
+
 // KrakendHeaderValue is the value of the custom KrakenD header
 var KrakendHeaderValue = fmt.Sprintf("Version %s", KrakendVersion)
 


### PR DESCRIPTION
…y CGO at build time so plugins can build using the same version

Signed-off-by: Daniel Ortiz <dortiz@krakend.io>