### PR TITLE
feat: wildcard routing support for mux

### DIFF
--- a/proxy/http.go
+++ b/proxy/http.go
@@ -106,6 +106,12 @@ func NewRequestBuilderMiddleware(remote *config.Backend) Middleware {
 		}
 		return func(ctx context.Context, request *Request) (*Response, error) {
 			r := request.Clone()
+			if v, ok := remote.ExtraConfig["wildcard"].(map[string]interface{}); v != nil && ok {
+				if keepPath, ok := v["keep_original_path"].(bool); keepPath && ok {
+					r.Method = remote.Method
+					return next[0](ctx, &r)
+				}
+			}
 			r.GeneratePath(remote.URLPattern)
 			r.Method = remote.Method
 			return next[0](ctx, &r)

--- a/router/gorilla/router.go
+++ b/router/gorilla/router.go
@@ -50,6 +50,11 @@ type gorillaEngine struct {
 
 // Handle implements the mux.Engine interface from the lura router package
 func (g gorillaEngine) Handle(pattern, method string, handler http.Handler) {
+
+	if strings.HasSuffix(method, ":wildcard") {
+		g.r.PathPrefix(pattern).Handler(handler)
+		return
+	}
 	g.r.Handle(pattern, handler).Methods(method)
 }
 

--- a/router/mux/endpoint.go
+++ b/router/mux/endpoint.go
@@ -154,6 +154,7 @@ func NewRequestBuilder(paramExtractor ParamExtractor) RequestBuilder {
 		}
 
 		return &proxy.Request{
+			Path:    r.URL.Path,
 			Method:  r.Method,
 			Query:   query,
 			Body:    r.Body,


### PR DESCRIPTION
added wildcard routing support for mux

To define a wild card route add below in `extra_config` in your Endpoint and Backend:
```json
{
  "wildcard": {
    "keep_original_path": true
  }
}
```
Eg.
```json
{
  "endpoint": "consume/ui",
  "method": "GET",
  "output_encoding": "no-op",
  "input_headers": [
    "*"
  ],
  "input_query_strings": [
    "*"
  ],
  "backend": [
    {
      "group": "UI",
      "host": [
        "https://ui:443"
      ],
      "url_pattern": "/consume/ui",
      "method": "GET",
      "encoding": "no-op",
      "extra_config": {
        "wildcard": {
          "keep_original_path": true
        }
      }
    }
  ],
  "extra_config": {
    "wildcard": {
      "keep_original_path": true
    }
  }
}
```

We are moving away from our old API gateway to a new one i.e **KrakenD** and we had wildcard routing for UI.  We found that the KrakenD community edition doesn't support wildcard routing. So we ended up modifying the code to support our use case.

We need KrakenD to act as an API gateway for all our backed APIs and with UI wild card route in our project.
It's as if no matching backend API route is found and if it is matching with our UI wildcard route then forward all those requests to UI.

Eg.
GET /consume/api/v1/users/{userid}
POST /consume/api/v1/users/{userid}
PUT /consume/api/v1/users/{userid}
.
.
.
GET /consume/ui (our wild card route added for UI)

Now if API requests come for GET /consume/ui/assets/xyz.json then it should be forwarded to UI with the original request path. Like **GET https://ui:443/consume/ui/assets/xyz.json**
