### PR TITLE
Add support for HTTP2 trailers

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -19,6 +19,7 @@ const Namespace = "github.com/devopsfaith/krakend/proxy"
 // Metadata is the Metadata of the Response which contains Headers and StatusCode
 type Metadata struct {
 	Headers    map[string][]string
+	Trailer    map[string][]string
 	StatusCode int
 }
 

--- a/router/mux/render.go
+++ b/router/mux/render.go
@@ -125,6 +125,10 @@ func noopRender(w http.ResponseWriter, response *proxy.Response) {
 		return
 	}
 
+	for k := range response.Metadata.Trailer {
+		w.Header().Add("Trailer", k)
+	}
+
 	for k, vs := range response.Metadata.Headers {
 		for _, v := range vs {
 			w.Header().Add(k, v)
@@ -134,8 +138,13 @@ func noopRender(w http.ResponseWriter, response *proxy.Response) {
 		w.WriteHeader(response.Metadata.StatusCode)
 	}
 
-	if response.Io == nil {
-		return
+	if response.Io != nil {
+		_, _ = io.Copy(w, response.Io)
 	}
-	io.Copy(w, response.Io)
+
+	for k, vs := range response.Metadata.Trailer {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
 }


### PR DESCRIPTION
This pull request makes it possible to proxy gRPC unary calls via `mux` router.

To achieve this we should properly handle HTTP2 trailers in the mux.