### PR TITLE
Fix/call response modifier plugin 597

### DIFF
--- a/proxy/plugin.go
+++ b/proxy/plugin.go
@@ -15,7 +15,7 @@ import (
 
 // NewPluginMiddleware returns an endpoint middleware wrapped (if required) with the plugin middleware.
 // The plugin middleware will try to load all the required plugins from the register and execute them in order.
-// RequestModifiers are executed before passing the request to the next middlware. ResponseModifiers are executed
+// RequestModifiers are executed before passing the request to the next middleware. ResponseModifiers are executed
 // once the response is returned from the next middleware.
 func NewPluginMiddleware(logger logging.Logger, endpoint *config.EndpointConfig) Middleware {
 	cfg, ok := endpoint.ExtraConfig[plugin.Namespace].(map[string]interface{})
@@ -29,7 +29,7 @@ func NewPluginMiddleware(logger logging.Logger, endpoint *config.EndpointConfig)
 
 // NewBackendPluginMiddleware returns a backend middleware wrapped (if required) with the plugin middleware.
 // The plugin middleware will try to load all the required plugins from the register and execute them in order.
-// RequestModifiers are executed before passing the request to the next middlware. ResponseModifiers are executed
+// RequestModifiers are executed before passing the request to the next middleware. ResponseModifiers are executed
 // once the response is returned from the next middleware.
 func NewBackendPluginMiddleware(logger logging.Logger, remote *config.Backend) Middleware {
 	cfg, ok := remote.ExtraConfig[plugin.Namespace].(map[string]interface{})

--- a/proxy/plugin/tests/logger/main.go
+++ b/proxy/plugin/tests/logger/main.go
@@ -25,7 +25,7 @@ func (r registerer) RegisterModifiers(f func(
 	appliesToResponse bool,
 )) {
 	f(string(r)+"-request", r.requestModifierFactory, true, false)
-	f(string(r)+"-response", r.reqsponseModifierFactory, false, true)
+	f(string(r)+"-response", r.responseModifierFactory, false, true)
 }
 
 func (registerer) RegisterLogger(in interface{}) {
@@ -47,7 +47,7 @@ func (registerer) requestModifierFactory(_ map[string]interface{}) func(interfac
 		return func(input interface{}) (interface{}, error) {
 			req, ok := input.(RequestWrapper)
 			if !ok {
-				return nil, unkownTypeErr
+				return nil, errUnknownType
 			}
 
 			return modifier(req), nil
@@ -58,7 +58,7 @@ func (registerer) requestModifierFactory(_ map[string]interface{}) func(interfac
 	return func(input interface{}) (interface{}, error) {
 		req, ok := input.(RequestWrapper)
 		if !ok {
-			return nil, unkownTypeErr
+			return nil, errUnknownType
 		}
 
 		r := modifier(req)
@@ -74,7 +74,7 @@ func (registerer) requestModifierFactory(_ map[string]interface{}) func(interfac
 	}
 }
 
-func (registerer) reqsponseModifierFactory(_ map[string]interface{}) func(interface{}) (interface{}, error) {
+func (registerer) responseModifierFactory(_ map[string]interface{}) func(interface{}) (interface{}, error) {
 	// check the cfg. If the modifier requires some configuration,
 	// it should be under the name of the plugin.
 	// ex: if this modifier required some A and B config params
@@ -96,7 +96,7 @@ func (registerer) reqsponseModifierFactory(_ map[string]interface{}) func(interf
 		return func(input interface{}) (interface{}, error) {
 			resp, ok := input.(ResponseWrapper)
 			if !ok {
-				return nil, unkownTypeErr
+				return nil, errUnknownType
 			}
 
 			fmt.Println("data:", resp.Data())
@@ -112,7 +112,7 @@ func (registerer) reqsponseModifierFactory(_ map[string]interface{}) func(interf
 	return func(input interface{}) (interface{}, error) {
 		resp, ok := input.(ResponseWrapper)
 		if !ok {
-			return nil, unkownTypeErr
+			return nil, errUnknownType
 		}
 
 		logger.Debug("data:", resp.Data())
@@ -136,7 +136,7 @@ func modifier(req RequestWrapper) requestWrapper {
 	}
 }
 
-var unkownTypeErr = errors.New("unknown request type")
+var errUnknownType = errors.New("unknown request type")
 
 type ResponseWrapper interface {
 	Data() map[string]interface{}


### PR DESCRIPTION
Fixes #597 
Check if next proxy resp is nil when returning early when there's an error 
If resp is not nil, for instance when we have a merged response and a mergeError with at least one of the backends returning a response we would still want to call a response modifier for that response.

Fixed a couple of typos