### PR TITLE
Provide a configuration point to allow access to the Response Headers from backends

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,7 @@
 name: Go
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:

--- a/config/config.go
+++ b/config/config.go
@@ -240,6 +240,8 @@ type Backend struct {
 	Mapping map[string]string `mapstructure:"mapping"`
 	// the encoding format
 	Encoding string `mapstructure:"encoding"`
+	// HeadersFromResponse defines the list of headers to pass from the backends
+	HeadersFromResponse []string `mapstructure:"response_headers"`
 	// the response to process is a collection
 	IsCollection bool `mapstructure:"is_collection"`
 	// name of the field to extract to the root. If empty, the formater will do nothing

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -157,10 +157,11 @@ func TestConfig_init(t *testing.T) {
 		Encoding:   "rss",
 	}
 	postBackend := Backend{
-		URLPattern: "/posts/{user}",
-		Host:       []string{"https://jsonplaceholder.typicode.com"},
-		Group:      "posts",
-		Encoding:   "xml",
+		URLPattern:          "/posts/{user}",
+		Host:                []string{"https://jsonplaceholder.typicode.com"},
+		Group:               "posts",
+		Encoding:            "xml",
+		HeadersFromResponse: []string{"X-Request-Id"},
 	}
 	userEndpoint := EndpointConfig{
 		Endpoint: "/users/{user}",
@@ -210,7 +211,7 @@ func TestConfig_init(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	if hash != "3YYe7crlYj5Qpm/oUoBqO2mQrKcalJmAoNfkRYM7aDI=" {
+	if hash != "L/J3zAB9Yyjfy0JdqbR7I+t6c0/KySnf4/2fRNun8Jc=" {
 		t.Errorf("unexpected hash: %s", hash)
 	}
 }

--- a/proxy/http.go
+++ b/proxy/http.go
@@ -40,7 +40,7 @@ func NewHTTPProxyWithHTTPExecutor(remote *config.Backend, re client.HTTPRequestE
 	}
 
 	ef := NewEntityFormatter(remote)
-	rp := DefaultHTTPResponseParserFactory(HTTPResponseParserConfig{dec, ef})
+	rp := DefaultHTTPResponseParserFactory(remote, HTTPResponseParserConfig{dec, ef})
 	return NewHTTPProxyDetailed(remote, re, client.GetHTTPStatusHandler(remote), rp)
 }
 


### PR DESCRIPTION
There is a need to be able to choose some response headers to be accessible, for example in plugins. A specific use case for this is the ability to tie a response to a request using a correlation id (X-Correlation-ID) in a header. At the moment there is no mechanism to do this.