### PR TITLE
Add configuration option allow_insecure_connections

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -162,6 +162,10 @@ type ServiceConfig struct {
 	// SequentialStart flags if the agents should be started sequentially
 	// before starting the router
 	SequentialStart bool `mapstructure:"sequential_start"`
+
+	// AllowInsecureConnections sets the http client tls configuration to allow
+	// insecure connections to the backends for development (enables InsecureSkipVerify)
+	AllowInsecureConnections bool `mapstructure:"allow_insecure_connections"`
 }
 
 // AsyncAgent defines the configuration of a single subscriber/consumer to be initialized

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -210,7 +210,7 @@ func TestConfig_init(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	if hash != "3YYe7crlYj5Qpm/oUoBqO2mQrKcalJmAoNfkRYM7aDI=" {
+	if hash != "ip9OZeBfyY9vrjovdU+IivbOev4bH1jDcT2EC9QU1U8=" {
 		t.Errorf("unexpected hash: %s", hash)
 	}
 }

--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -75,7 +75,7 @@ func InitHTTPDefaultTransport(cfg config.ServiceConfig) {
 			ResponseHeaderTimeout: cfg.ResponseHeaderTimeout,
 			ExpectContinueTimeout: cfg.ExpectContinueTimeout,
 			TLSHandshakeTimeout:   10 * time.Second,
-			TLSClientConfig:       &tls.Config{InsecureSkipVerify: cfg.AllowInsecureConnections},
+			TLSClientConfig:       &tls.Config{InsecureSkipVerify: cfg.AllowInsecureConnections}, // skipcq: GSC-G402
 		}
 	})
 }

--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -75,6 +75,7 @@ func InitHTTPDefaultTransport(cfg config.ServiceConfig) {
 			ResponseHeaderTimeout: cfg.ResponseHeaderTimeout,
 			ExpectContinueTimeout: cfg.ExpectContinueTimeout,
 			TLSHandshakeTimeout:   10 * time.Second,
+			TLSClientConfig:       &tls.Config{InsecureSkipVerify: cfg.AllowInsecureConnections},
 		}
 	})
 }


### PR DESCRIPTION
Sets the http client tls configuration to allow insecure connections to the backends for development when using self-signed certificates (enables InsecureSkipVerify).

Signed-off-by: Daniel Ortiz <dortiz@krakend.io>