### PR TITLE
Enable the gin context fallback

### DIFF
--- a/router/gin/engine.go
+++ b/router/gin/engine.go
@@ -38,6 +38,7 @@ func NewEngine(cfg config.ServiceConfig, opt EngineOptions) *gin.Engine {
 	engine.RedirectTrailingSlash = true
 	engine.RedirectFixedPath = true
 	engine.HandleMethodNotAllowed = true
+	engine.ContextWithFallback = true
 
 	paths := []string{}
 

--- a/router/gin/engine_test.go
+++ b/router/gin/engine_test.go
@@ -17,7 +17,9 @@ func TestNewEngine_contextIsPropagated(t *testing.T) {
 		EngineOptions{},
 	)
 
-	ctxKey := "foo"
+	type ctxKeyType string
+
+	ctxKey := ctxKeyType("foo")
 	ctxValue := "bar"
 
 	engine.GET("/some/path", func(c *gin.Context) {

--- a/router/gin/engine_test.go
+++ b/router/gin/engine_test.go
@@ -1,0 +1,50 @@
+package gin
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/luraproject/lura/v2/config"
+)
+
+func TestNewEngine_contextIsPropagated(t *testing.T) {
+	engine := NewEngine(
+		config.ServiceConfig{},
+		EngineOptions{},
+	)
+
+	ctxKey := "foo"
+	ctxValue := "bar"
+
+	engine.GET("/some/path", func(c *gin.Context) {
+		c.String(http.StatusOK, "%v", c.Value(ctxKey))
+	})
+
+	req, _ := http.NewRequest("GET", "/some/path", http.NoBody)
+	req = req.WithContext(context.WithValue(req.Context(), ctxKey, ctxValue))
+
+	w := httptest.NewRecorder()
+
+	engine.ServeHTTP(w, req)
+
+	resp := w.Result()
+
+	if sc := resp.StatusCode; sc != http.StatusOK {
+		t.Errorf("unexpected status code: %d", sc)
+		return
+	}
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("reading the response body: %s", err.Error())
+		return
+	}
+
+	if string(b) != ctxValue {
+		t.Errorf("unexpected value: %s", string(b))
+	}
+}


### PR DESCRIPTION
 so handler and client plugins can use the same context and share values between them.

Signed-off-by: Daniel Ortiz <dortiz@krakend.io>