### PR TITLE
reject requests with special chars in the params

### DIFF
--- a/router/gin/engine.go
+++ b/router/gin/engine.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/textproto"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -130,7 +131,7 @@ func paramChecker() gin.HandlerFunc {
 				c.AbortWithStatus(http.StatusBadRequest)
 				return
 			}
-			if s != param.Value {
+			if s != param.Value || strings.Contains(s, "?") || strings.Contains(s, "#") {
 				c.String(http.StatusBadRequest, "error: encoded url params")
 				c.AbortWithStatus(http.StatusBadRequest)
 				return


### PR DESCRIPTION
`?` and `#` are not allowed in url params

Signed-off-by: kpacha <dlopez@krakend.io>