### PR TITLE
Add a response error with the abitlity to set it's own encoding so us…

### DIFF
--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -89,6 +89,9 @@ func CustomErrorEndpointHandler(logger logging.Logger, errF server.ToHTTPError) 
 						c.Status(errF(err))
 					}
 					if returnErrorMsg {
+						if te, ok := err.(encodedResponseError); ok && te.Encoding() != "" {
+							c.Header("Content-Type", te.Encoding())
+						}
 						c.Writer.WriteString(err.Error())
 					}
 					cancel()
@@ -161,6 +164,11 @@ func NewRequest(headersToSend []string) func(*gin.Context, []string) *proxy.Requ
 			Headers: headers,
 		}
 	}
+}
+
+type encodedResponseError interface {
+	responseError
+	Encoding() string
 }
 
 type responseError interface {


### PR DESCRIPTION
…ers can customize the errors without forcing a text/plain encoding.

Signed-off-by: Daniel Ortiz <dortiz@krakend.io>