### PR TITLE
Fix race condition in shadowproxy

### DIFF
--- a/proxy/shadow.go
+++ b/proxy/shadow.go
@@ -97,8 +97,9 @@ func NewShadowProxy(p1, p2 Proxy) Proxy {
 func NewShadowProxyWithTimeout(timeout time.Duration, p1, p2 Proxy) Proxy {
 	return func(ctx context.Context, request *Request) (*Response, error) {
 		shadowCtx, cancel := newcontextWrapperWithTimeout(ctx, timeout)
+		shadowRequest := CloneRequest(request)
 		go func() {
-			p2(shadowCtx, CloneRequest(request))
+			p2(shadowCtx, shadowRequest)
 			cancel()
 		}()
 		return p1(ctx, request)


### PR DESCRIPTION
## About

To copy the request body from the primary request to the shadow request, the body buffer is read, copied, and re-attached to the primary request (see `proxy.CloneRequest`) in a separate Go routine. This is not thread-safe and can lead to a race condition where the primary proxy and the shadow proxy compete for reading the body.