### PR TITLE
Check function provided by request response modifier plugin is not nil

### DIFF
--- a/proxy/plugin.go
+++ b/proxy/plugin.go
@@ -47,8 +47,9 @@ func newPluginMiddleware(logger logging.Logger, tag, pattern string, cfg map[str
 		return EmptyMiddleware
 	}
 
-	reqModifiers := []func(interface{}) (interface{}, error){}
-	respModifiers := []func(interface{}) (interface{}, error){}
+	var reqModifiers []func(interface{}) (interface{}, error)
+
+	var respModifiers []func(interface{}) (interface{}, error)
 
 	for _, p := range plugins {
 		name, ok := p.(string)

--- a/proxy/plugin.go
+++ b/proxy/plugin.go
@@ -57,12 +57,16 @@ func newPluginMiddleware(logger logging.Logger, tag, pattern string, cfg map[str
 		}
 
 		if mf, ok := plugin.GetRequestModifier(name); ok {
-			reqModifiers = append(reqModifiers, mf(cfg))
+			if fn := mf(cfg); fn != nil {
+				reqModifiers = append(reqModifiers, fn)
+			}
 			continue
 		}
 
 		if mf, ok := plugin.GetResponseModifier(name); ok {
-			respModifiers = append(respModifiers, mf(cfg))
+			if fn := mf(cfg); fn != nil {
+				respModifiers = append(respModifiers, fn)
+			}
 		}
 	}
 


### PR DESCRIPTION
If a badly written third party request / response modifier plugin returns a nil function Lura could panic, so we add a check before adding if to the stack of request / response modifiers. 