### PR TITLE
Add client TLS Config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -169,6 +169,10 @@ type ServiceConfig struct {
 	// AllowInsecureConnections sets the http client tls configuration to allow
 	// insecure connections to the backends for development (enables InsecureSkipVerify)
 	AllowInsecureConnections bool `mapstructure:"allow_insecure_connections"`
+
+	// ClientTLS is used to configure the http default transport
+	// with TLS parameters
+	ClientTLS *ClientTLS `mapstructure:"client_tls"`
 }
 
 // AsyncAgent defines the configuration of a single subscriber/consumer to be initialized
@@ -274,17 +278,27 @@ type Plugin struct {
 
 // TLS defines the configuration params for enabling TLS (HTTPS & HTTP/2) at the router layer
 type TLS struct {
-	IsDisabled               bool     `mapstructure:"disabled"`
-	PublicKey                string   `mapstructure:"public_key"`
-	PrivateKey               string   `mapstructure:"private_key"`
+	IsDisabled          bool     `mapstructure:"disabled"`
+	PublicKey           string   `mapstructure:"public_key"`
+	PrivateKey          string   `mapstructure:"private_key"`
+	CaCerts             []string `mapstructure:"ca_certs"`
+	MinVersion          string   `mapstructure:"min_version"`
+	MaxVersion          string   `mapstructure:"max_version"`
+	CurvePreferences    []uint16 `mapstructure:"curve_preferences"`
+	CipherSuites        []uint16 `mapstructure:"cipher_suites"`
+	EnableMTLS          bool     `mapstructure:"enable_mtls"`
+	DisableSystemCaPool bool     `mapstructure:"disable_system_ca_pool"`
+}
+
+// ClientTLS defines the configuration params for an HTTP Client
+type ClientTLS struct {
+	AllowInsecureConnections bool     `mapstructure:"allow_insecure_connections"`
 	CaCerts                  []string `mapstructure:"ca_certs"`
+	DisableSystemCaPool      bool     `mapstructure:"disable_system_ca_pool"`
 	MinVersion               string   `mapstructure:"min_version"`
 	MaxVersion               string   `mapstructure:"max_version"`
 	CurvePreferences         []uint16 `mapstructure:"curve_preferences"`
-	PreferServerCipherSuites bool     `mapstructure:"prefer_server_cipher_suites"`
 	CipherSuites             []uint16 `mapstructure:"cipher_suites"`
-	EnableMTLS               bool     `mapstructure:"enable_mtls"`
-	DisableSystemCaPool      bool     `mapstructure:"disable_system_ca_pool"`
 }
 
 // ExtraConfig is a type to store extra configurations for customized behaviours

--- a/config/config.go
+++ b/config/config.go
@@ -278,21 +278,24 @@ type Plugin struct {
 
 // TLS defines the configuration params for enabling TLS (HTTPS & HTTP/2) at the router layer
 type TLS struct {
-	IsDisabled          bool     `mapstructure:"disabled"`
-	PublicKey           string   `mapstructure:"public_key"`
-	PrivateKey          string   `mapstructure:"private_key"`
-	CaCerts             []string `mapstructure:"ca_certs"`
-	MinVersion          string   `mapstructure:"min_version"`
-	MaxVersion          string   `mapstructure:"max_version"`
-	CurvePreferences    []uint16 `mapstructure:"curve_preferences"`
-	CipherSuites        []uint16 `mapstructure:"cipher_suites"`
-	EnableMTLS          bool     `mapstructure:"enable_mtls"`
-	DisableSystemCaPool bool     `mapstructure:"disable_system_ca_pool"`
+	IsDisabled               bool     `mapstructure:"disabled"`
+	PublicKey                string   `mapstructure:"public_key"`
+	PrivateKey               string   `mapstructure:"private_key"`
+	CaCerts                  []string `mapstructure:"ca_certs"`
+	MinVersion               string   `mapstructure:"min_version"`
+	MaxVersion               string   `mapstructure:"max_version"`
+	CurvePreferences         []uint16 `mapstructure:"curve_preferences"`
+	PreferServerCipherSuites bool     `mapstructure:"prefer_server_cipher_suites"`
+	CipherSuites             []uint16 `mapstructure:"cipher_suites"`
+	EnableMTLS               bool     `mapstructure:"enable_mtls"`
+	DisableSystemCaPool      bool     `mapstructure:"disable_system_ca_pool"`
 }
 
 // ClientTLS defines the configuration params for an HTTP Client
 type ClientTLS struct {
 	AllowInsecureConnections bool     `mapstructure:"allow_insecure_connections"`
+	RootCAs                  []string `mapstructure:"root_cas"`
+	DisableSystemRootPool    bool     `mapstructure:"disable_system_root_pool"`
 	CaCerts                  []string `mapstructure:"ca_certs"`
 	DisableSystemCaPool      bool     `mapstructure:"disable_system_ca_pool"`
 	MinVersion               string   `mapstructure:"min_version"`

--- a/config/config.go
+++ b/config/config.go
@@ -296,8 +296,6 @@ type ClientTLS struct {
 	AllowInsecureConnections bool     `mapstructure:"allow_insecure_connections"`
 	RootCAs                  []string `mapstructure:"root_cas"`
 	DisableSystemRootPool    bool     `mapstructure:"disable_system_root_pool"`
-	CaCerts                  []string `mapstructure:"ca_certs"`
-	DisableSystemCaPool      bool     `mapstructure:"disable_system_ca_pool"`
 	MinVersion               string   `mapstructure:"min_version"`
 	MaxVersion               string   `mapstructure:"max_version"`
 	CurvePreferences         []uint16 `mapstructure:"curve_preferences"`

--- a/config/config.go
+++ b/config/config.go
@@ -294,8 +294,8 @@ type TLS struct {
 // ClientTLS defines the configuration params for an HTTP Client
 type ClientTLS struct {
 	AllowInsecureConnections bool     `mapstructure:"allow_insecure_connections"`
-	RootCAs                  []string `mapstructure:"root_cas"`
-	DisableSystemRootPool    bool     `mapstructure:"disable_system_root_pool"`
+	CaCerts                  []string `mapstructure:"ca_certs"`
+	DisableSystemCaPool      bool     `mapstructure:"disable_system_ca_pool"`
 	MinVersion               string   `mapstructure:"min_version"`
 	MaxVersion               string   `mapstructure:"max_version"`
 	CurvePreferences         []uint16 `mapstructure:"curve_preferences"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -210,7 +210,7 @@ func TestConfig_init(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	if hash != "N1AP3YSocze/xZpcFmMflCIaqvBNyifukZXKFTj856Y=" {
+	if hash != "LJINwAtU9pEWEpQTz06r28wq7nSP5c05WsiQ3ZaVBeI=" {
 		t.Errorf("unexpected hash: %s", hash)
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -210,7 +210,7 @@ func TestConfig_init(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	if hash != "LJINwAtU9pEWEpQTz06r28wq7nSP5c05WsiQ3ZaVBeI=" {
+	if hash != "xk3NYRFW6tfsTtcDfXVcnqCi8Qj7S875u84fvOpOyq8=" {
 		t.Errorf("unexpected hash: %s", hash)
 	}
 }

--- a/config/parser.go
+++ b/config/parser.go
@@ -161,6 +161,7 @@ type parseableServiceConfig struct {
 	Echo                  bool                       `json:"echo_endpoint"`
 	Plugin                *Plugin                    `json:"plugin,omitempty"`
 	TLS                   *parseableTLS              `json:"tls,omitempty"`
+	ClientTLS             *parseableClientTLS        `json:"client_tls,omitempty"`
 }
 
 func (p *parseableServiceConfig) normalize() ServiceConfig {
@@ -192,17 +193,27 @@ func (p *parseableServiceConfig) normalize() ServiceConfig {
 	}
 	if p.TLS != nil {
 		cfg.TLS = &TLS{
-			IsDisabled:               p.TLS.IsDisabled,
-			PublicKey:                p.TLS.PublicKey,
-			PrivateKey:               p.TLS.PrivateKey,
-			CaCerts:                  p.TLS.CaCerts,
-			MinVersion:               p.TLS.MinVersion,
-			MaxVersion:               p.TLS.MaxVersion,
-			CurvePreferences:         p.TLS.CurvePreferences,
-			PreferServerCipherSuites: p.TLS.PreferServerCipherSuites,
-			CipherSuites:             p.TLS.CipherSuites,
-			EnableMTLS:               p.TLS.EnableMTLS,
-			DisableSystemCaPool:      p.TLS.DisableSystemCaPool,
+			IsDisabled:          p.TLS.IsDisabled,
+			PublicKey:           p.TLS.PublicKey,
+			PrivateKey:          p.TLS.PrivateKey,
+			CaCerts:             p.TLS.CaCerts,
+			MinVersion:          p.TLS.MinVersion,
+			MaxVersion:          p.TLS.MaxVersion,
+			CurvePreferences:    p.TLS.CurvePreferences,
+			CipherSuites:        p.TLS.CipherSuites,
+			EnableMTLS:          p.TLS.EnableMTLS,
+			DisableSystemCaPool: p.TLS.DisableSystemCaPool,
+		}
+	}
+	if p.ClientTLS != nil {
+		cfg.ClientTLS = &ClientTLS{
+			AllowInsecureConnections: p.ClientTLS.AllowInsecureConnections,
+			CaCerts:                  p.ClientTLS.CaCerts,
+			DisableSystemCaPool:      p.ClientTLS.DisableSystemCaPool,
+			MinVersion:               p.ClientTLS.MinVersion,
+			MaxVersion:               p.ClientTLS.MaxVersion,
+			CurvePreferences:         p.ClientTLS.CurvePreferences,
+			CipherSuites:             p.ClientTLS.CipherSuites,
 		}
 	}
 	if p.ExtraConfig != nil {
@@ -233,6 +244,16 @@ type parseableTLS struct {
 	CipherSuites             []uint16 `json:"cipher_suites"`
 	EnableMTLS               bool     `json:"enable_mtls"`
 	DisableSystemCaPool      bool     `json:"disable_system_ca_pool"`
+}
+
+type parseableClientTLS struct {
+	AllowInsecureConnections bool     `json:"allow_insecure_connections"`
+	CaCerts                  []string `json:"ca_certs"`
+	DisableSystemCaPool      bool     `json:"disable_system_ca_pool"`
+	MinVersion               string   `json:"min_version"`
+	MaxVersion               string   `json:"max_version"`
+	CurvePreferences         []uint16 `json:"curve_preferences"`
+	CipherSuites             []uint16 `json:"cipher_suites"`
 }
 
 type parseableEndpointConfig struct {

--- a/config/parser.go
+++ b/config/parser.go
@@ -209,8 +209,8 @@ func (p *parseableServiceConfig) normalize() ServiceConfig {
 	if p.ClientTLS != nil {
 		cfg.ClientTLS = &ClientTLS{
 			AllowInsecureConnections: p.ClientTLS.AllowInsecureConnections,
-			RootCAs:                  p.ClientTLS.RootCAs,
-			DisableSystemRootPool:    p.ClientTLS.DisableSystemRootPool,
+			CaCerts:                  p.ClientTLS.CaCerts,
+			DisableSystemCaPool:      p.ClientTLS.DisableSystemCaPool,
 			MinVersion:               p.ClientTLS.MinVersion,
 			MaxVersion:               p.ClientTLS.MaxVersion,
 			CurvePreferences:         p.ClientTLS.CurvePreferences,
@@ -249,8 +249,8 @@ type parseableTLS struct {
 
 type parseableClientTLS struct {
 	AllowInsecureConnections bool     `json:"allow_insecure_connections"`
-	RootCAs                  []string `json:"root_cas"`
-	DisableSystemRootPool    bool     `json:"disable_system_root_pool"`
+	CaCerts                  []string `json:"ca_certs"`
+	DisableSystemCaPool      bool     `json:"disable_system_ca_pool"`
 	MinVersion               string   `json:"min_version"`
 	MaxVersion               string   `json:"max_version"`
 	CurvePreferences         []uint16 `json:"curve_preferences"`

--- a/config/parser.go
+++ b/config/parser.go
@@ -193,23 +193,24 @@ func (p *parseableServiceConfig) normalize() ServiceConfig {
 	}
 	if p.TLS != nil {
 		cfg.TLS = &TLS{
-			IsDisabled:          p.TLS.IsDisabled,
-			PublicKey:           p.TLS.PublicKey,
-			PrivateKey:          p.TLS.PrivateKey,
-			CaCerts:             p.TLS.CaCerts,
-			MinVersion:          p.TLS.MinVersion,
-			MaxVersion:          p.TLS.MaxVersion,
-			CurvePreferences:    p.TLS.CurvePreferences,
-			CipherSuites:        p.TLS.CipherSuites,
-			EnableMTLS:          p.TLS.EnableMTLS,
-			DisableSystemCaPool: p.TLS.DisableSystemCaPool,
+			IsDisabled:               p.TLS.IsDisabled,
+			PublicKey:                p.TLS.PublicKey,
+			PrivateKey:               p.TLS.PrivateKey,
+			CaCerts:                  p.TLS.CaCerts,
+			MinVersion:               p.TLS.MinVersion,
+			MaxVersion:               p.TLS.MaxVersion,
+			CurvePreferences:         p.TLS.CurvePreferences,
+			PreferServerCipherSuites: p.TLS.PreferServerCipherSuites,
+			CipherSuites:             p.TLS.CipherSuites,
+			EnableMTLS:               p.TLS.EnableMTLS,
+			DisableSystemCaPool:      p.TLS.DisableSystemCaPool,
 		}
 	}
 	if p.ClientTLS != nil {
 		cfg.ClientTLS = &ClientTLS{
 			AllowInsecureConnections: p.ClientTLS.AllowInsecureConnections,
-			CaCerts:                  p.ClientTLS.CaCerts,
-			DisableSystemCaPool:      p.ClientTLS.DisableSystemCaPool,
+			RootCAs:                  p.ClientTLS.RootCAs,
+			DisableSystemRootPool:    p.ClientTLS.DisableSystemRootPool,
 			MinVersion:               p.ClientTLS.MinVersion,
 			MaxVersion:               p.ClientTLS.MaxVersion,
 			CurvePreferences:         p.ClientTLS.CurvePreferences,
@@ -248,8 +249,8 @@ type parseableTLS struct {
 
 type parseableClientTLS struct {
 	AllowInsecureConnections bool     `json:"allow_insecure_connections"`
-	CaCerts                  []string `json:"ca_certs"`
-	DisableSystemCaPool      bool     `json:"disable_system_ca_pool"`
+	RootCAs                  []string `json:"root_cas"`
+	DisableSystemRootPool    bool     `json:"disable_system_root_pool"`
 	MinVersion               string   `json:"min_version"`
 	MaxVersion               string   `json:"max_version"`
 	CurvePreferences         []uint16 `json:"curve_preferences"`

--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -189,7 +189,7 @@ func ParseTLSConfigWithLogger(cfg *config.TLS, logger logging.Logger) *tls.Confi
 func ParseClientTLSConfigWithLogger(cfg *config.ClientTLS, logger logging.Logger) *tls.Config {
 	return &tls.Config{
 		InsecureSkipVerify: cfg.AllowInsecureConnections,
-		RootCAs:            LoadCertPool(cfg.DisableSystemCaPool, cfg.CaCerts, logger),
+		RootCAs:            LoadCertPool(cfg.DisableSystemRootPool, cfg.RootCAs, logger),
 		MinVersion:         parseTLSVersion(cfg.MinVersion),
 		MaxVersion:         parseTLSVersion(cfg.MaxVersion),
 		CurvePreferences:   parseCurveIDs(cfg.CurvePreferences),

--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -187,13 +187,11 @@ func ParseTLSConfigWithLogger(cfg *config.TLS, logger logging.Logger) *tls.Confi
 }
 
 func ParseClientTLSConfigWithLogger(cfg *config.ClientTLS, logger logging.Logger) *tls.Config {
-	minVersion := parseTLSVersion(cfg.MinVersion)
-	maxVersion := parseTLSVersion(cfg.MaxVersion)
 	return &tls.Config{
 		InsecureSkipVerify: cfg.AllowInsecureConnections,
 		RootCAs:            LoadCertPool(cfg.DisableSystemCaPool, cfg.CaCerts, logger),
-		MinVersion:         minVersion,
-		MaxVersion:         maxVersion,
+		MinVersion:         parseTLSVersion(cfg.MinVersion),
+		MaxVersion:         parseTLSVersion(cfg.MaxVersion),
 		CurvePreferences:   parseCurveIDs(cfg.CurvePreferences),
 		CipherSuites:       parseCipherSuites(cfg.CipherSuites),
 	}

--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -59,6 +59,16 @@ var (
 
 // InitHTTPDefaultTransport ensures the default HTTP transport is configured just once per execution
 func InitHTTPDefaultTransport(cfg config.ServiceConfig) {
+	InitHTTPDefaultTransportWithLogger(cfg, nil)
+}
+
+func InitHTTPDefaultTransportWithLogger(cfg config.ServiceConfig, logger logging.Logger) {
+	if logger == nil {
+		logger = logging.NoOp
+	}
+	if cfg.AllowInsecureConnections {
+		cfg.ClientTLS.AllowInsecureConnections = true
+	}
 	onceTransportConfig.Do(func() {
 		http.DefaultTransport = &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
@@ -76,7 +86,7 @@ func InitHTTPDefaultTransport(cfg config.ServiceConfig) {
 			ResponseHeaderTimeout: cfg.ResponseHeaderTimeout,
 			ExpectContinueTimeout: cfg.ExpectContinueTimeout,
 			TLSHandshakeTimeout:   10 * time.Second,
-			TLSClientConfig:       &tls.Config{InsecureSkipVerify: cfg.AllowInsecureConnections}, // skipcq: GSC-G402
+			TLSClientConfig:       ParseClientTLSConfigWithLogger(cfg.ClientTLS, logger),
 		}
 	})
 }
@@ -152,34 +162,16 @@ func ParseTLSConfigWithLogger(cfg *config.TLS, logger logging.Logger) *tls.Confi
 	}
 
 	tlsConfig := &tls.Config{
-		MinVersion:               parseTLSVersion(cfg.MinVersion),
-		MaxVersion:               parseTLSVersion(cfg.MaxVersion),
-		CurvePreferences:         parseCurveIDs(cfg),
-		PreferServerCipherSuites: cfg.PreferServerCipherSuites,
-		CipherSuites:             parseCipherSuites(cfg),
+		MinVersion:       parseTLSVersion(cfg.MinVersion),
+		MaxVersion:       parseTLSVersion(cfg.MaxVersion),
+		CurvePreferences: parseCurveIDs(cfg.CurvePreferences),
+		CipherSuites:     parseCipherSuites(cfg.CipherSuites),
 	}
 	if !cfg.EnableMTLS {
 		return tlsConfig
 	}
 
-	certPool := x509.NewCertPool()
-	if !cfg.DisableSystemCaPool {
-		if systemCertPool, err := x509.SystemCertPool(); err == nil {
-			certPool = systemCertPool
-		} else {
-			logger.Error(fmt.Sprintf("%s Cannot load system CA pool: %s", loggerPrefix, err.Error()))
-		}
-	}
-
-	if len(cfg.CaCerts) > 0 {
-		for _, path := range cfg.CaCerts {
-			if ca, err := os.ReadFile(path); err == nil {
-				certPool.AppendCertsFromPEM(ca)
-			} else {
-				logger.Error(fmt.Sprintf("%s Cannot load certificate CA %s: %s", loggerPrefix, path, err.Error()))
-			}
-		}
-	}
+	certPool := LoadCertPool(cfg.DisableSystemCaPool, cfg.CaCerts, logger)
 
 	caCert, err := os.ReadFile(cfg.PublicKey)
 	if err != nil {
@@ -194,6 +186,39 @@ func ParseTLSConfigWithLogger(cfg *config.TLS, logger logging.Logger) *tls.Confi
 	return tlsConfig
 }
 
+func ParseClientTLSConfigWithLogger(cfg *config.ClientTLS, logger logging.Logger) *tls.Config {
+	minVersion := parseTLSVersion(cfg.MinVersion)
+	maxVersion := parseTLSVersion(cfg.MaxVersion)
+	return &tls.Config{
+		InsecureSkipVerify: cfg.AllowInsecureConnections,
+		RootCAs:            LoadCertPool(cfg.DisableSystemCaPool, cfg.CaCerts, logger),
+		MinVersion:         minVersion,
+		MaxVersion:         maxVersion,
+		CurvePreferences:   parseCurveIDs(cfg.CurvePreferences),
+		CipherSuites:       parseCipherSuites(cfg.CipherSuites),
+	}
+}
+
+func LoadCertPool(disableSystemCaPool bool, caCerts []string, logger logging.Logger) *x509.CertPool {
+	certPool := x509.NewCertPool()
+	if !disableSystemCaPool {
+		if systemCertPool, err := x509.SystemCertPool(); err == nil {
+			certPool = systemCertPool
+		} else {
+			logger.Error(fmt.Sprintf("%s Cannot load system CA pool: %s", loggerPrefix, err.Error()))
+		}
+	}
+
+	for _, path := range caCerts {
+		if ca, err := os.ReadFile(path); err == nil {
+			certPool.AppendCertsFromPEM(ca)
+		} else {
+			logger.Error(fmt.Sprintf("%s Cannot load certificate CA %s: %s", loggerPrefix, path, err.Error()))
+		}
+	}
+	return certPool
+}
+
 func parseTLSVersion(key string) uint16 {
 	if v, ok := versions[key]; ok {
 		return v
@@ -201,28 +226,28 @@ func parseTLSVersion(key string) uint16 {
 	return tls.VersionTLS13
 }
 
-func parseCurveIDs(cfg *config.TLS) []tls.CurveID {
-	l := len(cfg.CurvePreferences)
+func parseCurveIDs(curvePreferences []uint16) []tls.CurveID {
+	l := len(curvePreferences)
 	if l == 0 {
 		return defaultCurves
 	}
 
-	curves := make([]tls.CurveID, len(cfg.CurvePreferences))
+	curves := make([]tls.CurveID, len(curvePreferences))
 	for i := range curves {
-		curves[i] = tls.CurveID(cfg.CurvePreferences[i])
+		curves[i] = tls.CurveID(curvePreferences[i])
 	}
 	return curves
 }
 
-func parseCipherSuites(cfg *config.TLS) []uint16 {
-	l := len(cfg.CipherSuites)
+func parseCipherSuites(cipherSuites []uint16) []uint16 {
+	l := len(cipherSuites)
 	if l == 0 {
 		return defaultCipherSuites
 	}
 
 	cs := make([]uint16, l)
 	for i := range cs {
-		cs[i] = uint16(cfg.CipherSuites[i])
+		cs[i] = uint16(cipherSuites[i])
 	}
 	return cs
 }

--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -187,6 +187,9 @@ func ParseTLSConfigWithLogger(cfg *config.TLS, logger logging.Logger) *tls.Confi
 }
 
 func ParseClientTLSConfigWithLogger(cfg *config.ClientTLS, logger logging.Logger) *tls.Config {
+	if cfg == nil {
+		return nil
+	}
 	return &tls.Config{
 		InsecureSkipVerify: cfg.AllowInsecureConnections,
 		RootCAs:            LoadCertPool(cfg.DisableSystemRootPool, cfg.RootCAs, logger),

--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -171,7 +171,7 @@ func ParseTLSConfigWithLogger(cfg *config.TLS, logger logging.Logger) *tls.Confi
 		return tlsConfig
 	}
 
-	certPool := LoadCertPool(cfg.DisableSystemCaPool, cfg.CaCerts, logger)
+	certPool := loadCertPool(cfg.DisableSystemCaPool, cfg.CaCerts, logger)
 
 	caCert, err := os.ReadFile(cfg.PublicKey)
 	if err != nil {
@@ -192,7 +192,7 @@ func ParseClientTLSConfigWithLogger(cfg *config.ClientTLS, logger logging.Logger
 	}
 	return &tls.Config{
 		InsecureSkipVerify: cfg.AllowInsecureConnections,
-		RootCAs:            LoadCertPool(cfg.DisableSystemRootPool, cfg.RootCAs, logger),
+		RootCAs:            loadCertPool(cfg.DisableSystemCaPool, cfg.CaCerts, logger),
 		MinVersion:         parseTLSVersion(cfg.MinVersion),
 		MaxVersion:         parseTLSVersion(cfg.MaxVersion),
 		CurvePreferences:   parseCurveIDs(cfg.CurvePreferences),
@@ -200,7 +200,7 @@ func ParseClientTLSConfigWithLogger(cfg *config.ClientTLS, logger logging.Logger
 	}
 }
 
-func LoadCertPool(disableSystemCaPool bool, caCerts []string, logger logging.Logger) *x509.CertPool {
+func loadCertPool(disableSystemCaPool bool, caCerts []string, logger logging.Logger) *x509.CertPool {
 	certPool := x509.NewCertPool()
 	if !disableSystemCaPool {
 		if systemCertPool, err := x509.SystemCertPool(); err == nil {

--- a/transport/http/server/server_test.go
+++ b/transport/http/server/server_test.go
@@ -69,8 +69,8 @@ func TestRunServer_TLS(t *testing.T) {
 	// client to connect to the server
 	InitHTTPDefaultTransport(config.ServiceConfig{
 		ClientTLS: &config.ClientTLS{
-			CaCerts:             []string{"ca.pem"},
-			DisableSystemCaPool: true,
+			RootCAs:               []string{"ca.pem"},
+			DisableSystemRootPool: true,
 		},
 	})
 	rawClient := http.Client{}

--- a/transport/http/server/server_test.go
+++ b/transport/http/server/server_test.go
@@ -262,7 +262,7 @@ func Test_parseTLSVersion(t *testing.T) {
 
 func Test_parseCurveIDs(t *testing.T) {
 	original := []uint16{1, 2, 3}
-	cs := parseCurveIDs(&config.TLS{CurvePreferences: original})
+	cs := parseCurveIDs(original)
 	for k, v := range cs {
 		if original[k] != uint16(v) {
 			t.Errorf("unexpected curves %v. expected: %v", cs, original)
@@ -272,7 +272,7 @@ func Test_parseCurveIDs(t *testing.T) {
 
 func Test_parseCipherSuites(t *testing.T) {
 	original := []uint16{1, 2, 3}
-	cs := parseCipherSuites(&config.TLS{CipherSuites: original})
+	cs := parseCipherSuites(original)
 	for k, v := range cs {
 		if original[k] != uint16(v) {
 			t.Errorf("unexpected ciphersuites %v. expected: %v", cs, original)

--- a/transport/http/server/server_test.go
+++ b/transport/http/server/server_test.go
@@ -69,8 +69,8 @@ func TestRunServer_TLS(t *testing.T) {
 	// client to connect to the server
 	InitHTTPDefaultTransport(config.ServiceConfig{
 		ClientTLS: &config.ClientTLS{
-			RootCAs:               []string{"ca.pem"},
-			DisableSystemRootPool: true,
+			CaCerts:             []string{"ca.pem"},
+			DisableSystemCaPool: true,
 		},
 	})
 	rawClient := http.Client{}

--- a/transport/http/server/server_test.go
+++ b/transport/http/server/server_test.go
@@ -64,6 +64,26 @@ func TestRunServer_TLS(t *testing.T) {
 		t.Errorf("unexpected status code: %d", resp.StatusCode)
 		return
 	}
+
+	// now lets initialize the global default transport and use a regular
+	// client to connect to the server
+	InitHTTPDefaultTransport(config.ServiceConfig{
+		ClientTLS: &config.ClientTLS{
+			CaCerts:             []string{"ca.pem"},
+			DisableSystemCaPool: true,
+		},
+	})
+	rawClient := http.Client{}
+	resp, err = rawClient.Get(fmt.Sprintf("https://localhost:%d", port))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("unexpected status code: %d", resp.StatusCode)
+		return
+	}
+
 	cancel()
 
 	if err = <-done; err != nil {


### PR DESCRIPTION
- `PreferServerCipherSuites` from config, as it is deprecated and has no effect (but not removed to keep contract): https://pkg.go.dev/crypto/tls#Config:
 
```go
	// PreferServerCipherSuites is a legacy field and has no effect.
	//
	// It used to control whether the server would follow the client's or the
	// server's preference. Servers now select the best mutually supported
	// cipher suite based on logic that takes into account inferred client
	// hardware, server hardware, and security.
	//
	// Deprecated: PreferServerCipherSuites is ignored.
	PreferServerCipherSuites [bool](https://pkg.go.dev/builtin#bool)
```

- Add `ClientTLS` struct to configure global TLS options for the http client that will be used to connect to backends.
- `AllowInsecureConnections` now is part of the `client_tls` configurations, and should not be used (but is still respected if set)