### PR TITLE
fix: missing Echo value when getting configuration from parseable con…

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -172,6 +172,7 @@ func (p *parseableServiceConfig) normalize() ServiceConfig {
 		Port:                  p.Port,
 		Version:               p.Version,
 		Debug:                 p.Debug,
+		Echo:                  p.Echo,
 		ReadTimeout:           parseDuration(p.ReadTimeout),
 		WriteTimeout:          parseDuration(p.WriteTimeout),
 		IdleTimeout:           parseDuration(p.IdleTimeout),


### PR DESCRIPTION
Fix: missing Echo value when getting service configuration from parseable config.