### PR TITLE
add tests for error response writer

### DIFF
--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -23,7 +23,7 @@ type HandlerFactory func(*config.EndpointConfig, proxy.Proxy) gin.HandlerFunc
 
 // ErrorResponseWriter writes the string representation of an error into the response body
 // and sets a Content-Type header for errors that implement the encodedResponseError interface.
-var ErrorResponseWriter = func(c *gin.Context, statusCode int, err error) {
+var ErrorResponseWriter = func(c *gin.Context, err error) {
 	if te, ok := err.(encodedResponseError); ok && te.Encoding() != "" {
 		c.Header("Content-Type", te.Encoding())
 	}
@@ -92,15 +92,13 @@ func CustomErrorEndpointHandler(logger logging.Logger, errF server.ToHTTPError) 
 				}
 
 				if response == nil {
-					var statusCode int
 					if t, ok := err.(responseError); ok {
-						statusCode = t.StatusCode()
+						c.Status(t.StatusCode())
 					} else {
-						statusCode = errF(err)
+						c.Status(errF(err))
 					}
-					c.Status(statusCode)
 					if returnErrorMsg {
-						ErrorResponseWriter(c, statusCode, err)
+						ErrorResponseWriter(c, err)
 					}
 					cancel()
 					return

--- a/router/gin/engine.go
+++ b/router/gin/engine.go
@@ -137,13 +137,15 @@ func paramChecker() gin.HandlerFunc {
 		for _, param := range c.Params {
 			s, err := url.PathUnescape(param.Value)
 			if err != nil {
-				ErrorResponseWriter(c, http.StatusBadRequest, fmt.Errorf("error: %s", err))
-				c.AbortWithStatus(http.StatusBadRequest)
+				c.Status(http.StatusBadRequest)
+				ErrorResponseWriter(c, fmt.Errorf("error: %s", err))
+				c.Abort()
 				return
 			}
 			if s != param.Value || strings.Contains(s, "?") || strings.Contains(s, "#") {
-				ErrorResponseWriter(c, http.StatusBadRequest, errors.New("error: encoded url params"))
-				c.AbortWithStatus(http.StatusBadRequest)
+				c.Status(http.StatusBadRequest)
+				ErrorResponseWriter(c, errors.New("error: encoded url params"))
+				c.Abort()
 				return
 			}
 		}


### PR DESCRIPTION
## About

Fix minor bug that was introduced [here](https://github.com/luraproject/lura/pull/659): If a request is aborted with `error: encoded url params`, the status code should be set to `400` (currently returns `200`, but correctly aborts the request). To avoid similar issues, it's generally preferable to set the response status before calling `ErrorResponseWriter`.