### PR TITLE
Add mTLS config for backend clients

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -297,13 +297,14 @@ type TLS struct {
 
 // ClientTLS defines the configuration params for an HTTP Client
 type ClientTLS struct {
-	AllowInsecureConnections bool     `mapstructure:"allow_insecure_connections"`
-	CaCerts                  []string `mapstructure:"ca_certs"`
-	DisableSystemCaPool      bool     `mapstructure:"disable_system_ca_pool"`
-	MinVersion               string   `mapstructure:"min_version"`
-	MaxVersion               string   `mapstructure:"max_version"`
-	CurvePreferences         []uint16 `mapstructure:"curve_preferences"`
-	CipherSuites             []uint16 `mapstructure:"cipher_suites"`
+	AllowInsecureConnections bool       `mapstructure:"allow_insecure_connections"`
+	CaCerts                  []string   `mapstructure:"ca_certs"`
+	DisableSystemCaPool      bool       `mapstructure:"disable_system_ca_pool"`
+	MinVersion               string     `mapstructure:"min_version"`
+	MaxVersion               string     `mapstructure:"max_version"`
+	CurvePreferences         []uint16   `mapstructure:"curve_preferences"`
+	CipherSuites             []uint16   `mapstructure:"cipher_suites"`
+	ClientCerts              [][]string `mapstructure:"client_cert"`
 }
 
 // ExtraConfig is a type to store extra configurations for customized behaviours

--- a/config/config.go
+++ b/config/config.go
@@ -304,7 +304,7 @@ type ClientTLS struct {
 	MaxVersion               string     `mapstructure:"max_version"`
 	CurvePreferences         []uint16   `mapstructure:"curve_preferences"`
 	CipherSuites             []uint16   `mapstructure:"cipher_suites"`
-	ClientCerts              [][]string `mapstructure:"client_cert"`
+	ClientCerts              [][]string `mapstructure:"client_certs"`
 }
 
 // ExtraConfig is a type to store extra configurations for customized behaviours

--- a/config/parser.go
+++ b/config/parser.go
@@ -216,6 +216,7 @@ func (p *parseableServiceConfig) normalize() ServiceConfig {
 			MaxVersion:               p.ClientTLS.MaxVersion,
 			CurvePreferences:         p.ClientTLS.CurvePreferences,
 			CipherSuites:             p.ClientTLS.CipherSuites,
+			ClientCerts:              p.ClientTLS.ClientCerts,
 		}
 	}
 	if p.ExtraConfig != nil {
@@ -249,13 +250,14 @@ type parseableTLS struct {
 }
 
 type parseableClientTLS struct {
-	AllowInsecureConnections bool     `json:"allow_insecure_connections"`
-	CaCerts                  []string `json:"ca_certs"`
-	DisableSystemCaPool      bool     `json:"disable_system_ca_pool"`
-	MinVersion               string   `json:"min_version"`
-	MaxVersion               string   `json:"max_version"`
-	CurvePreferences         []uint16 `json:"curve_preferences"`
-	CipherSuites             []uint16 `json:"cipher_suites"`
+	AllowInsecureConnections bool       `json:"allow_insecure_connections"`
+	CaCerts                  []string   `json:"ca_certs"`
+	DisableSystemCaPool      bool       `json:"disable_system_ca_pool"`
+	MinVersion               string     `json:"min_version"`
+	MaxVersion               string     `json:"max_version"`
+	CurvePreferences         []uint16   `json:"curve_preferences"`
+	CipherSuites             []uint16   `json:"cipher_suites"`
+	ClientCerts              [][]string `json:"client_certs"`
 }
 
 type parseableEndpointConfig struct {

--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -70,25 +70,29 @@ func InitHTTPDefaultTransportWithLogger(cfg config.ServiceConfig, logger logging
 		cfg.ClientTLS.AllowInsecureConnections = true
 	}
 	onceTransportConfig.Do(func() {
-		http.DefaultTransport = &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
-				Timeout:       cfg.DialerTimeout,
-				KeepAlive:     cfg.DialerKeepAlive,
-				FallbackDelay: cfg.DialerFallbackDelay,
-				DualStack:     true,
-			}).DialContext,
-			DisableCompression:    cfg.DisableCompression,
-			DisableKeepAlives:     cfg.DisableKeepAlives,
-			MaxIdleConns:          cfg.MaxIdleConns,
-			MaxIdleConnsPerHost:   cfg.MaxIdleConnsPerHost,
-			IdleConnTimeout:       cfg.IdleConnTimeout,
-			ResponseHeaderTimeout: cfg.ResponseHeaderTimeout,
-			ExpectContinueTimeout: cfg.ExpectContinueTimeout,
-			TLSHandshakeTimeout:   10 * time.Second,
-			TLSClientConfig:       ParseClientTLSConfigWithLogger(cfg.ClientTLS, logger),
-		}
+		http.DefaultTransport = newTransport(cfg, logger)
 	})
+}
+
+func newTransport(cfg config.ServiceConfig, logger logging.Logger) *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:       cfg.DialerTimeout,
+			KeepAlive:     cfg.DialerKeepAlive,
+			FallbackDelay: cfg.DialerFallbackDelay,
+			DualStack:     true,
+		}).DialContext,
+		DisableCompression:    cfg.DisableCompression,
+		DisableKeepAlives:     cfg.DisableKeepAlives,
+		MaxIdleConns:          cfg.MaxIdleConns,
+		MaxIdleConnsPerHost:   cfg.MaxIdleConnsPerHost,
+		IdleConnTimeout:       cfg.IdleConnTimeout,
+		ResponseHeaderTimeout: cfg.ResponseHeaderTimeout,
+		ExpectContinueTimeout: cfg.ExpectContinueTimeout,
+		TLSHandshakeTimeout:   10 * time.Second,
+		TLSClientConfig:       ParseClientTLSConfigWithLogger(cfg.ClientTLS, logger),
+	}
 }
 
 // RunServer runs a http.Server with the given handler and configuration.

--- a/transport/http/server/server_test.go
+++ b/transport/http/server/server_test.go
@@ -11,7 +11,6 @@ import (
 	"html"
 	"log"
 	"math/rand"
-	"net"
 	"net/http"
 	"os"
 	"testing"
@@ -147,24 +146,7 @@ func TestRunServer_MTLS(t *testing.T) {
 	// clientTLS config.
 	// This is a copy of the code we can find inside
 	// InitHTTPDefaultTransportWithLogger(serviceConfig, nil):
-	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:       cfg.DialerTimeout,
-			KeepAlive:     cfg.DialerKeepAlive,
-			FallbackDelay: cfg.DialerFallbackDelay,
-			DualStack:     true,
-		}).DialContext,
-		DisableCompression:    cfg.DisableCompression,
-		DisableKeepAlives:     cfg.DisableKeepAlives,
-		MaxIdleConns:          cfg.MaxIdleConns,
-		MaxIdleConnsPerHost:   cfg.MaxIdleConnsPerHost,
-		IdleConnTimeout:       cfg.IdleConnTimeout,
-		ResponseHeaderTimeout: cfg.ResponseHeaderTimeout,
-		ExpectContinueTimeout: cfg.ExpectContinueTimeout,
-		TLSHandshakeTimeout:   10 * time.Second,
-		TLSClientConfig:       ParseClientTLSConfigWithLogger(cfg.ClientTLS, logger),
-	}
+	transport := newTransport(cfg, logger)
 
 	defClient := http.Client{
 		Transport: transport,

--- a/transport/http/server/server_test.go
+++ b/transport/http/server/server_test.go
@@ -99,7 +99,6 @@ func TestRunServer_MTLS(t *testing.T) {
 	defer cancel()
 
 	port := newPort()
-	port = 36517
 	done := make(chan error)
 
 	serviceConfig := config.ServiceConfig{


### PR DESCRIPTION
With this changes Lura should be able to provide client certificates to the backend service.