### PR TITLE
initialize the ClientTLS if required

### DIFF
--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -67,6 +67,9 @@ func InitHTTPDefaultTransportWithLogger(cfg config.ServiceConfig, logger logging
 		logger = logging.NoOp
 	}
 	if cfg.AllowInsecureConnections {
+		if cfg.ClientTLS == nil {
+			cfg.ClientTLS = &config.ClientTLS{}
+		}
 		cfg.ClientTLS.AllowInsecureConnections = true
 	}
 	onceTransportConfig.Do(func() {


### PR DESCRIPTION
If the `allow_insecure_connections` global flag is enabled and no `client_tls` section is defined, the TLS initialization panics