### PR TITLE
fix broken links in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ the change with the owners before investing a lot of time coding. The process
 could be:
 
 1. Open an issue explaining the improvment or fix you want to add
-2. [Fork the project](https://github.com/luraproject/lura/fork_select)
+2. [Fork the project](https://github.com/luraproject/lura/fork)
 3. Code it in your fork
 4. Submit a [pull request](https://help.github.com/articles/creating-a-pull-request) referencing the issue
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3151/badge)
 ![Docker Pulls](https://img.shields.io/docker/pulls/devopsfaith/krakend.svg)
 [![Slack Widget](https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=red)](https://gophers.slack.com/messages/lura)
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fluraproject%2Flura.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fluraproject%2Flura?ref=badge_shield)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fluraproject%2Flura.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fluraproject%2Flura?ref=badge_shield&issueType=license)
 
 
 An open framework to assemble ultra performance API Gateways with middlewares; formerly known as _KrakenD framework_, and core service of the [KrakenD API Gateway](http://www.krakend.io).

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,10 +6,8 @@
 
 Visit the [framework overview](/docs/OVERVIEW.md) for details about the components of the Lura project.
 
-### Examples
-
-1. [gin router](/examples/gin/README.md)
-2. [mux router](/examples/mux/README.md)
+A good example about how to use it can be found in the [KrakenD CE](https://github.com/krakend/krakend-ce)
+API Gateway project.
 
 ## Configuration file
 
@@ -20,3 +18,6 @@ Visit the [framework overview](/docs/OVERVIEW.md) for details about the componen
 Check out the [benchmark results](/docs/BENCHMARKS.md) of several Lura components.
 
 ## Contributing
+
+Read the guidelines about [contributing](../CONTRIBUTING.md).
+


### PR DESCRIPTION
Remove links to examples in `docs/README.md` that are no longuer valid, and fix badge and fork link.