### PR TITLE
Fix h2c support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -160,6 +160,9 @@ type ServiceConfig struct {
 	// the router layer
 	TLS *TLS `mapstructure:"tls"`
 
+	// UseH2C enables h2c support.
+	UseH2C bool `json:"use_h2c"`
+
 	// run lura in debug mode
 	Debug     bool `mapstructure:"debug_endpoint"`
 	Echo      bool `mapstructure:"echo_endpoint"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -211,7 +211,7 @@ func TestConfig_init(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	if hash != "FK9W9HSD9jkExuf53M9SUs5bCwlwRde5kRX0cn8rGm4=" {
+	if hash != "NILRcvZq9y+zinGtRRfG+Zm1ORVE3gI2gjpcgDI3A/Q=" {
 		t.Errorf("unexpected hash: %s", hash)
 	}
 }

--- a/router/gin/engine.go
+++ b/router/gin/engine.go
@@ -73,6 +73,7 @@ func NewEngine(cfg config.ServiceConfig, opt EngineOptions) *gin.Engine {
 				engine.AppEngine = ginOptions.AppEngine
 				engine.MaxMultipartMemory = ginOptions.MaxMultipartMemory
 				engine.RemoveExtraSlash = ginOptions.RemoveExtraSlash
+				engine.UseH2C = ginOptions.UseH2C
 				paths = ginOptions.LoggerSkipPaths
 
 				returnErrorMsg = ginOptions.ReturnErrorMsg

--- a/router/gin/engine.go
+++ b/router/gin/engine.go
@@ -73,7 +73,6 @@ func NewEngine(cfg config.ServiceConfig, opt EngineOptions) *gin.Engine {
 				engine.AppEngine = ginOptions.AppEngine
 				engine.MaxMultipartMemory = ginOptions.MaxMultipartMemory
 				engine.RemoveExtraSlash = ginOptions.RemoveExtraSlash
-				engine.UseH2C = ginOptions.UseH2C
 				paths = ginOptions.LoggerSkipPaths
 
 				returnErrorMsg = ginOptions.ReturnErrorMsg

--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -41,8 +40,6 @@ const (
 	// HeaderIncompleteResponseValue is the value of the CompleteResponseHeader
 	// if the response is not complete
 	HeaderIncompleteResponseValue = "false"
-	// ginNamespace used to grab router extra config
-	ginNamespace = "github_com/luraproject/lura/router/gin"
 )
 
 var (
@@ -144,22 +141,9 @@ func NewServer(cfg config.ServiceConfig, handler http.Handler) *http.Server {
 	return NewServerWithLogger(cfg, handler, nil)
 }
 
-type serverOptions struct {
-	// UseH2C enable h2c support.
-	UseH2C bool `json:"use_h2c"`
-}
-
 func NewServerWithLogger(cfg config.ServiceConfig, handler http.Handler, logger logging.Logger) *http.Server {
-	// wrap handler with h2c handler if it is enabled
-	srvCfg := serverOptions{}
-	if v, ok := cfg.ExtraConfig[ginNamespace]; ok {
-		if d, err := json.Marshal(v); err == nil {
-			if err := json.Unmarshal(d, &srvCfg); err == nil {
-				if srvCfg.UseH2C {
-					handler = h2c.NewHandler(handler, &http2.Server{})
-				}
-			}
-		}
+	if cfg.UseH2C {
+		handler = h2c.NewHandler(handler, &http2.Server{})
 	}
 
 	return &http.Server{

--- a/transport/http/server/server_test.go
+++ b/transport/http/server/server_test.go
@@ -214,10 +214,8 @@ func TestRunServer_h2c(t *testing.T) {
 		done <- RunServer(
 			ctx,
 			config.ServiceConfig{
-				Port: port,
-				ExtraConfig: config.ExtraConfig{
-					ginNamespace: serverOptions{UseH2C: true},
-				},
+				Port:   port,
+				UseH2C: true,
 			},
 			http.HandlerFunc(dummyHandler),
 		)


### PR DESCRIPTION
## About

This solves [#786](https://github.com/krakend/krakend-ce/issues/786) issue in krakend-ce repo.

Move support for h2c from gin router init to http server
init.

## Description

If we initialize h2c using gin router it will use h2c handler
to wrap handler with all routes registered on gin router.
The problem is that it is possible to construct router factory
with RunServer function which will wrap h2c handler with additional
handler. Any logic in this handler will not be able to understand
http2 cleartext requests.

We have this example in krakend-ce repository where CORS support
is added through RunServer function. Then we have CORS handler ->
h2c handler -> Gin router.

Simplest fix is to move h2c support to server initialization
and add h2c handler as the outermost layer.