### PR TITLE
create logger wrapper to store additional information

### DIFF
--- a/logging/annotated_logger.go
+++ b/logging/annotated_logger.go
@@ -27,35 +27,35 @@ func NewAnnotatedLogger(l Logger, appendAnnotation string) (AnnotatedLogger, err
 
 // Debug logs a message using DEBUG as log level.
 func (l AnnotatedLogger) Debug(v ...interface{}) {
-	l.wrapped.Debug(l.appendLog(v))
+	l.wrapped.Debug(l.appendLog(v)...)
 }
 
 // Info logs a message using INFO as log level.
 func (l AnnotatedLogger) Info(v ...interface{}) {
-	l.wrapped.Info(l.appendLog(v))
+	l.wrapped.Info(l.appendLog(v)...)
 }
 
 // Warning logs a message using WARNING as log level.
 func (l AnnotatedLogger) Warning(v ...interface{}) {
-	l.wrapped.Warning(l.appendLog(v))
+	l.wrapped.Warning(l.appendLog(v)...)
 }
 
 // Error logs a message using ERROR as log level.
 func (l AnnotatedLogger) Error(v ...interface{}) {
-	l.wrapped.Error(l.appendLog(v))
+	l.wrapped.Error(l.appendLog(v)...)
 }
 
 // Critical logs a message using CRITICAL as log level.
 func (l AnnotatedLogger) Critical(v ...interface{}) {
-	l.wrapped.Critical(l.appendLog(v))
+	l.wrapped.Critical(l.appendLog(v)...)
 }
 
 // Fatal is equivalent to l.Critical(fmt.Sprint()) followed by a call to os.Exit(1).
 func (l AnnotatedLogger) Fatal(v ...interface{}) {
-	l.wrapped.Fatal(l.appendLog(v))
+	l.wrapped.Fatal(l.appendLog(v)...)
 }
 
-func (l AnnotatedLogger) appendLog(v ...interface{}) []interface{} {
+func (l AnnotatedLogger) appendLog(v []interface{}) []interface{} {
 	if len(l.appendAnnotation) == 0 {
 		return v
 	}

--- a/logging/annotated_logger.go
+++ b/logging/annotated_logger.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package logging
+
+// AnnotatedLogger wraps a Logger and appends information to
+// each one of the received logs.
+type AnnotatedLogger struct {
+	appendAnnotation string
+	wrapped          Logger
+}
+
+// NewAnnotatedLogger creates and returns a Logger object
+func NewAnnotatedLogger(l Logger, appendAnnotation string) (AnnotatedLogger, error) {
+	if al, ok := l.(AnnotatedLogger); ok {
+		// if the given logger is already an annotated logger, we
+		// can combine the two appended anotations and save a wrap around
+		if len(al.appendAnnotation) > 0 {
+			appendAnnotation = al.appendAnnotation + " " + appendAnnotation
+		}
+		l = al.wrapped
+	}
+	return AnnotatedLogger{
+		appendAnnotation: appendAnnotation,
+		wrapped:          l,
+	}, nil
+}
+
+// Debug logs a message using DEBUG as log level.
+func (l AnnotatedLogger) Debug(v ...interface{}) {
+	l.wrapped.Debug(l.appendLog(v))
+}
+
+// Info logs a message using INFO as log level.
+func (l AnnotatedLogger) Info(v ...interface{}) {
+	l.wrapped.Info(l.appendLog(v))
+}
+
+// Warning logs a message using WARNING as log level.
+func (l AnnotatedLogger) Warning(v ...interface{}) {
+	l.wrapped.Warning(l.appendLog(v))
+}
+
+// Error logs a message using ERROR as log level.
+func (l AnnotatedLogger) Error(v ...interface{}) {
+	l.wrapped.Error(l.appendLog(v))
+}
+
+// Critical logs a message using CRITICAL as log level.
+func (l AnnotatedLogger) Critical(v ...interface{}) {
+	l.wrapped.Critical(l.appendLog(v))
+}
+
+// Fatal is equivalent to l.Critical(fmt.Sprint()) followed by a call to os.Exit(1).
+func (l AnnotatedLogger) Fatal(v ...interface{}) {
+	l.wrapped.Fatal(l.appendLog(v))
+}
+
+func (l AnnotatedLogger) appendLog(v ...interface{}) []interface{} {
+	if len(l.appendAnnotation) == 0 {
+		return v
+	}
+	msg := make([]interface{}, len(v)+1)
+	copy(msg, v)
+	msg[len(v)] = l.appendAnnotation
+	return msg
+}

--- a/logging/annotated_logger_test.go
+++ b/logging/annotated_logger_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package logging
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestNewAnnotatedLogger(t *testing.T) {
+	buff := bytes.NewBuffer(make([]byte, 1024))
+	bl, _ := NewLogger("DEBUG", buff, "PREFIX")
+
+	al, _ := NewAnnotatedLogger(bl, "Mortadelo")
+	al.Info("A")
+
+	s := buff.String()
+	if !strings.HasSuffix(s, "A Mortadelo") {
+		t.Errorf("missing suffix: %s", s)
+	}
+}
+
+func TestWrappedAnnotatedLogger(t *testing.T) {
+	buff := bytes.NewBuffer(make([]byte, 1024))
+	bl, _ := NewLogger("DEBUG", buff, "PREFIX")
+
+	al, _ := NewAnnotatedLogger(bl, "Mortadelo")
+	al, _ = NewAnnotatedLogger(al, "Filemon")
+	al.Warning("B")
+
+	s := buff.String()
+	if !strings.HasSuffix(s, "B Mortadelo Filemon") {
+		t.Errorf("missing suffix: %s", s)
+	}
+}

--- a/logging/annotated_logger_test.go
+++ b/logging/annotated_logger_test.go
@@ -8,15 +8,27 @@ import (
 	"testing"
 )
 
+func TestRegularLogger(t *testing.T) {
+	buff := bytes.NewBuffer(make([]byte, 1024))
+	bl, _ := NewLogger("DEBUG", buff, "PREFIX")
+
+	bl.Info("A", "B", "C")
+
+	s := buff.String()
+	if !strings.Contains(s, "A B C") {
+		t.Errorf("missing: A B C : %s", s)
+	}
+}
+
 func TestNewAnnotatedLogger(t *testing.T) {
 	buff := bytes.NewBuffer(make([]byte, 1024))
 	bl, _ := NewLogger("DEBUG", buff, "PREFIX")
 
 	al, _ := NewAnnotatedLogger(bl, "Mortadelo")
-	al.Info("A")
+	al.Info("A", "B", "C")
 
 	s := buff.String()
-	if !strings.HasSuffix(s, "A Mortadelo") {
+	if !strings.Contains(s, "A B C Mortadelo") {
 		t.Errorf("missing suffix: %s", s)
 	}
 }
@@ -27,10 +39,10 @@ func TestWrappedAnnotatedLogger(t *testing.T) {
 
 	al, _ := NewAnnotatedLogger(bl, "Mortadelo")
 	al, _ = NewAnnotatedLogger(al, "Filemon")
-	al.Warning("B")
+	al.Warning("B", "C", "D")
 
 	s := buff.String()
-	if !strings.HasSuffix(s, "B Mortadelo Filemon") {
+	if !strings.Contains(s, "B C D Mortadelo Filemon") {
 		t.Errorf("missing suffix: %s", s)
 	}
 }


### PR DESCRIPTION
We would like to add additional info about the endpoint a backend belongs to, by wrapping the provided logger, with a logger that stores that additional information.