### PR TITLE
Fix for parsing use_h2c config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -161,7 +161,7 @@ type ServiceConfig struct {
 	TLS *TLS `mapstructure:"tls"`
 
 	// UseH2C enables h2c support.
-	UseH2C bool `json:"use_h2c"`
+	UseH2C bool `mapstructure:"use_h2c"`
 
 	// run lura in debug mode
 	Debug     bool `mapstructure:"debug_endpoint"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -211,7 +211,7 @@ func TestConfig_init(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	if hash != "NILRcvZq9y+zinGtRRfG+Zm1ORVE3gI2gjpcgDI3A/Q=" {
+	if hash != "GdZTJtCn9ZHj3iBR1ZxmZL65HjbTCU8HhbDG8YWudAo=" {
 		t.Errorf("unexpected hash: %s", hash)
 	}
 }


### PR DESCRIPTION
In [#694](https://github.com/luraproject/lura/pull/694) I fixed issued with h2c support and CORS. There was small bug which slipped through code review. New config field does not use correct struct tag.

Changed `json` to `mapstructure`.