### PR TITLE
Add parent endpoint info to Backend

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -280,6 +280,11 @@ type Backend struct {
 	HeadersToPass []string `mapstructure:"input_headers"`
 	// QueryStringsToPass has the list of query string params to be sent to the backend
 	QueryStringsToPass []string `mapstructure:"input_query_strings"`
+
+	// ParentEndpoint is to be filled by the parent endpoint with its pattern enpoint
+	// so logs and other instrumentation can output better info (thus, it is not loaded
+	// with `mapstructure` or `json` tags).
+	ParentEndpoint string `json:"-" mapstructure:"-"`
 }
 
 // Plugin contains the config required by the plugin module
@@ -497,6 +502,8 @@ func (s *ServiceConfig) initEndpoints() error {
 		e.ExtraConfig.sanitize()
 
 		for j, b := range e.Backend {
+			// we "tell" the backend which is his parent endpoint
+			b.ParentEndpoint = e.Endpoint
 			if err := s.initBackendDefaults(i, j); err != nil {
 				return err
 			}

--- a/proxy/concurrent.go
+++ b/proxy/concurrent.go
@@ -14,14 +14,14 @@ import (
 // NewConcurrentMiddlewareWithLogger creates a proxy middleware that enables sending several requests concurrently
 func NewConcurrentMiddlewareWithLogger(logger logging.Logger, remote *config.Backend) Middleware {
 	if remote.ConcurrentCalls == 1 {
-		logger.Fatal("too few concurrent calls: NewConcurrentMiddleware expects more than 1 concurrent call, got %d", remote.ConcurrentCalls)
+		logger.Fatal("too few concurrent calls for %s -> %s: NewConcurrentMiddleware expects more than 1 concurrent call, got %d", remote.ParentEndpoint, remote.URLPattern, remote.ConcurrentCalls)
 		return nil
 	}
 	serviceTimeout := time.Duration(75*remote.Timeout.Nanoseconds()/100) * time.Nanosecond
 
 	return func(next ...Proxy) Proxy {
 		if len(next) > 1 {
-			logger.Fatal("too many proxies for this proxy middleware: NewConcurrentMiddleware only accepts 1 proxy, got %d", len(next))
+			logger.Fatal("too many proxies for this %s -> %s proxy middleware: NewConcurrentMiddleware only accepts 1 proxy, got %d", remote.ParentEndpoint, remote.URLPattern, len(next))
 			return nil
 		}
 

--- a/proxy/graphql.go
+++ b/proxy/graphql.go
@@ -28,7 +28,7 @@ func NewGraphQLMiddleware(logger logging.Logger, remote *config.Backend) Middlew
 	if err != nil {
 		if err != graphql.ErrNoConfigFound {
 			logger.Warning(
-				fmt.Sprintf("[BACKEND: %s][GraphQL] %s", remote.URLPattern, err.Error()))
+				fmt.Sprintf("[BACKEND: %s -> %s][GraphQL] %s", remote.ParentEndpoint, remote.URLPattern, err.Error()))
 		}
 		return emptyMiddlewareFallback(logger)
 	}
@@ -68,13 +68,14 @@ func NewGraphQLMiddleware(logger logging.Logger, remote *config.Backend) Middlew
 
 	return func(next ...Proxy) Proxy {
 		if len(next) > 1 {
-			logger.Fatal("too many proxies for this proxy middleware: NewGraphQLMiddleware only accepts 1 proxy, got %d", len(next))
+			logger.Fatal("too many proxies for this %s -> %s proxy middleware: NewGraphQLMiddleware only accepts 1 proxy, got %d", remote.ParentEndpoint, remote.URLPattern, len(next))
 			return nil
 		}
 
 		logger.Debug(
 			fmt.Sprintf(
-				"[BACKEND: %s][GraphQL] Operation: %s, Method: %s",
+				"[BACKEND: %s -> %s][GraphQL] Operation: %s, Method: %s",
+				remote.ParentEndpoint,
 				remote.URLPattern,
 				opt.Type,
 				opt.Method,

--- a/proxy/headers_filter.go
+++ b/proxy/headers_filter.go
@@ -18,7 +18,7 @@ func NewFilterHeadersMiddleware(logger logging.Logger, remote *config.Backend) M
 
 	return func(next ...Proxy) Proxy {
 		if len(next) > 1 {
-			logger.Fatal("too many proxies for this proxy middleware: NewFilterHeadersMiddleware only accepts 1 proxy, got %d", len(next))
+			logger.Fatal("too many proxies for this %s -> %s proxy middleware: NewFilterHeadersMiddleware only accepts 1 proxy, got %d", remote.ParentEndpoint, remote.URLPattern, len(next))
 			return nil
 		}
 		nextProxy := next[0]

--- a/proxy/http.go
+++ b/proxy/http.go
@@ -111,7 +111,7 @@ func NewRequestBuilderMiddlewareWithLogger(logger logging.Logger, remote *config
 func newRequestBuilderMiddleware(l logging.Logger, remote *config.Backend) Middleware {
 	return func(next ...Proxy) Proxy {
 		if len(next) > 1 {
-			l.Fatal("too many proxies for this proxy middleware: newRequestBuilderMiddleware only accepts 1 proxy, got %d", len(next))
+			l.Fatal("too many proxies for this %s -> %s proxy middleware: newRequestBuilderMiddleware only accepts 1 proxy, got %d", remote.ParentEndpoint, remote.URLPattern, len(next))
 			return nil
 		}
 		return func(ctx context.Context, request *Request) (*Response, error) {

--- a/proxy/plugin.go
+++ b/proxy/plugin.go
@@ -38,7 +38,8 @@ func NewBackendPluginMiddleware(logger logging.Logger, remote *config.Backend) M
 		return emptyMiddlewareFallback(logger)
 	}
 
-	return newPluginMiddleware(logger, "BACKEND", remote.URLPattern, cfg)
+	return newPluginMiddleware(logger, "BACKEND",
+		fmt.Sprintf("%s -> %s", remote.ParentEndpoint, remote.URLPattern), cfg)
 }
 
 func newPluginMiddleware(logger logging.Logger, tag, pattern string, cfg map[string]interface{}) Middleware {

--- a/proxy/query_strings_filter.go
+++ b/proxy/query_strings_filter.go
@@ -19,7 +19,7 @@ func NewFilterQueryStringsMiddleware(logger logging.Logger, remote *config.Backe
 
 	return func(next ...Proxy) Proxy {
 		if len(next) > 1 {
-			logger.Fatal("too many proxies for this proxy middleware: NewFilterQueryStringsMiddleware only accepts 1 proxy, got %d", len(next))
+			logger.Fatal("too many proxies for this %s -> %s proxy middleware: NewFilterQueryStringsMiddleware only accepts 1 proxy, got %d", remote.ParentEndpoint, remote.URLPattern, len(next))
 			return nil
 		}
 		nextProxy := next[0]

--- a/transport/http/client/plugin/executor.go
+++ b/transport/http/client/plugin/executor.go
@@ -4,6 +4,7 @@ package plugin
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 
@@ -27,7 +28,7 @@ func HTTPRequestExecutorWithContext(
 	next func(*config.Backend) client.HTTPRequestExecutor,
 ) func(*config.Backend) client.HTTPRequestExecutor {
 	return func(cfg *config.Backend) client.HTTPRequestExecutor {
-		logPrefix := "[BACKEND: " + cfg.URLPattern + "]"
+		logPrefix := fmt.Sprintf("[BACKEND: %s -> %s]", cfg.ParentEndpoint, cfg.URLPattern)
 		v, ok := cfg.ExtraConfig[Namespace]
 		if !ok {
 			return next(cfg)


### PR DESCRIPTION
Add `ParentEndpoint` to `Backend` config structure, so logs about a backend can identify where the issue is (to allow identification when the same remote call pattern is used in different endpoints).