### PR TITLE
Add parent endpoint method to backend logs.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -285,6 +285,10 @@ type Backend struct {
 	// so logs and other instrumentation can output better info (thus, it is not loaded
 	// with `mapstructure` or `json` tags).
 	ParentEndpoint string `json:"-" mapstructure:"-"`
+	// ParentEndpointMethod is to be filled by the parent endpoint with its enpoint method
+	// so logs and other instrumentation can output better info (thus, it is not loaded
+	// with `mapstructure` or `json` tags).
+	ParentEndpointMethod string `json:"-" mapstructure:"-"`
 }
 
 // Plugin contains the config required by the plugin module
@@ -504,6 +508,7 @@ func (s *ServiceConfig) initEndpoints() error {
 		for j, b := range e.Backend {
 			// we "tell" the backend which is his parent endpoint
 			b.ParentEndpoint = e.Endpoint
+			b.ParentEndpointMethod = e.Method
 			if err := s.initBackendDefaults(i, j); err != nil {
 				return err
 			}

--- a/proxy/concurrent.go
+++ b/proxy/concurrent.go
@@ -14,14 +14,16 @@ import (
 // NewConcurrentMiddlewareWithLogger creates a proxy middleware that enables sending several requests concurrently
 func NewConcurrentMiddlewareWithLogger(logger logging.Logger, remote *config.Backend) Middleware {
 	if remote.ConcurrentCalls == 1 {
-		logger.Fatal("too few concurrent calls for %s -> %s: NewConcurrentMiddleware expects more than 1 concurrent call, got %d", remote.ParentEndpoint, remote.URLPattern, remote.ConcurrentCalls)
+		logger.Fatal("too few concurrent calls for %s %s -> %s: NewConcurrentMiddleware expects more than 1 concurrent call, got %d",
+			remote.ParentEndpointMethod, remote.ParentEndpoint, remote.URLPattern, remote.ConcurrentCalls)
 		return nil
 	}
 	serviceTimeout := time.Duration(75*remote.Timeout.Nanoseconds()/100) * time.Nanosecond
 
 	return func(next ...Proxy) Proxy {
 		if len(next) > 1 {
-			logger.Fatal("too many proxies for this %s -> %s proxy middleware: NewConcurrentMiddleware only accepts 1 proxy, got %d", remote.ParentEndpoint, remote.URLPattern, len(next))
+			logger.Fatal("too many proxies for this %s -> %s proxy middleware: NewConcurrentMiddleware only accepts 1 proxy, got %d",
+				remote.ParentEndpointMethod, remote.ParentEndpoint, remote.URLPattern, len(next))
 			return nil
 		}
 

--- a/proxy/graphql.go
+++ b/proxy/graphql.go
@@ -28,7 +28,7 @@ func NewGraphQLMiddleware(logger logging.Logger, remote *config.Backend) Middlew
 	if err != nil {
 		if err != graphql.ErrNoConfigFound {
 			logger.Warning(
-				fmt.Sprintf("[BACKEND: %s -> %s][GraphQL] %s", remote.ParentEndpoint, remote.URLPattern, err.Error()))
+				fmt.Sprintf("[BACKEND: %s %s -> %s][GraphQL] %s", remote.ParentEndpoint, remote.ParentEndpoint, remote.URLPattern, err.Error()))
 		}
 		return emptyMiddlewareFallback(logger)
 	}
@@ -68,13 +68,15 @@ func NewGraphQLMiddleware(logger logging.Logger, remote *config.Backend) Middlew
 
 	return func(next ...Proxy) Proxy {
 		if len(next) > 1 {
-			logger.Fatal("too many proxies for this %s -> %s proxy middleware: NewGraphQLMiddleware only accepts 1 proxy, got %d", remote.ParentEndpoint, remote.URLPattern, len(next))
+			logger.Fatal("too many proxies for this %s %s -> %s proxy middleware: NewGraphQLMiddleware only accepts 1 proxy, got %d",
+				remote.ParentEndpointMethod, remote.ParentEndpoint, remote.URLPattern, len(next))
 			return nil
 		}
 
 		logger.Debug(
 			fmt.Sprintf(
-				"[BACKEND: %s -> %s][GraphQL] Operation: %s, Method: %s",
+				"[BACKEND: %s %s -> %s][GraphQL] Operation: %s, Method: %s",
+				remote.ParentEndpointMethod,
 				remote.ParentEndpoint,
 				remote.URLPattern,
 				opt.Type,

--- a/proxy/headers_filter.go
+++ b/proxy/headers_filter.go
@@ -18,7 +18,7 @@ func NewFilterHeadersMiddleware(logger logging.Logger, remote *config.Backend) M
 
 	return func(next ...Proxy) Proxy {
 		if len(next) > 1 {
-			logger.Fatal("too many proxies for this %s -> %s proxy middleware: NewFilterHeadersMiddleware only accepts 1 proxy, got %d", remote.ParentEndpoint, remote.URLPattern, len(next))
+			logger.Fatal("too many proxies for this %s %s -> %s proxy middleware: NewFilterHeadersMiddleware only accepts 1 proxy, got %d", remote.ParentEndpointMethod, remote.ParentEndpoint, remote.URLPattern, len(next))
 			return nil
 		}
 		nextProxy := next[0]

--- a/proxy/http.go
+++ b/proxy/http.go
@@ -111,7 +111,7 @@ func NewRequestBuilderMiddlewareWithLogger(logger logging.Logger, remote *config
 func newRequestBuilderMiddleware(l logging.Logger, remote *config.Backend) Middleware {
 	return func(next ...Proxy) Proxy {
 		if len(next) > 1 {
-			l.Fatal("too many proxies for this %s -> %s proxy middleware: newRequestBuilderMiddleware only accepts 1 proxy, got %d", remote.ParentEndpoint, remote.URLPattern, len(next))
+			l.Fatal("too many proxies for this %s %s -> %s proxy middleware: newRequestBuilderMiddleware only accepts 1 proxy, got %d", remote.ParentEndpointMethod, remote.ParentEndpoint, remote.URLPattern, len(next))
 			return nil
 		}
 		return func(ctx context.Context, request *Request) (*Response, error) {

--- a/proxy/plugin.go
+++ b/proxy/plugin.go
@@ -39,7 +39,7 @@ func NewBackendPluginMiddleware(logger logging.Logger, remote *config.Backend) M
 	}
 
 	return newPluginMiddleware(logger, "BACKEND",
-		fmt.Sprintf("%s -> %s", remote.ParentEndpoint, remote.URLPattern), cfg)
+		fmt.Sprintf("%s %s -> %s", remote.ParentEndpointMethod, remote.ParentEndpoint, remote.URLPattern), cfg)
 }
 
 func newPluginMiddleware(logger logging.Logger, tag, pattern string, cfg map[string]interface{}) Middleware {

--- a/proxy/query_strings_filter.go
+++ b/proxy/query_strings_filter.go
@@ -19,7 +19,7 @@ func NewFilterQueryStringsMiddleware(logger logging.Logger, remote *config.Backe
 
 	return func(next ...Proxy) Proxy {
 		if len(next) > 1 {
-			logger.Fatal("too many proxies for this %s -> %s proxy middleware: NewFilterQueryStringsMiddleware only accepts 1 proxy, got %d", remote.ParentEndpoint, remote.URLPattern, len(next))
+			logger.Fatal("too many proxies for this %s %s -> %s proxy middleware: NewFilterQueryStringsMiddleware only accepts 1 proxy, got %d", remote.ParentEndpointMethod, remote.ParentEndpoint, remote.URLPattern, len(next))
 			return nil
 		}
 		nextProxy := next[0]

--- a/transport/http/client/plugin/executor.go
+++ b/transport/http/client/plugin/executor.go
@@ -28,7 +28,7 @@ func HTTPRequestExecutorWithContext(
 	next func(*config.Backend) client.HTTPRequestExecutor,
 ) func(*config.Backend) client.HTTPRequestExecutor {
 	return func(cfg *config.Backend) client.HTTPRequestExecutor {
-		logPrefix := fmt.Sprintf("[BACKEND: %s -> %s]", cfg.ParentEndpoint, cfg.URLPattern)
+		logPrefix := fmt.Sprintf("[BACKEND: %s %s -> %s]", cfg.ParentEndpointMethod, cfg.ParentEndpoint, cfg.URLPattern)
 		v, ok := cfg.ExtraConfig[Namespace]
 		if !ok {
 			return next(cfg)


### PR DESCRIPTION
Related to this PR: https://github.com/luraproject/lura/pull/702/files , where we added the parent endpoint, I found that we should have added the request method in order uniquely identify the parent endpoint.