### PR TITLE
fix: allow `*` usage in endpoint pattern

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -361,7 +361,7 @@ var ExtraConfigAlias = map[string]string{}
 var (
 	simpleURLKeysPattern    = regexp.MustCompile(`\{([\w\-\.:/]+)\}`)
 	sequentialParamsPattern = regexp.MustCompile(`^(resp[\d]+_.+)?(JWT\.([\w\-\.:/]+))?$`)
-	invalidPattern          = `^[^/]|\*.|/__(debug|echo|health)(/.*)?$`
+	invalidPattern          = `^[^/]|/__(debug|echo|health)(/.*)?$`
 	errInvalidHost          = errors.New("invalid host")
 	errInvalidNoOpEncoding  = errors.New("can not use NoOp encoding with more than one backends connected to the same endpoint")
 	defaultPort             = 8080


### PR DESCRIPTION
Hello,

I noticed that the current regex pattern does not allow the use of the * character. This PR aims to enable the usage of *. In the Gin framework, the /endpoint/*any pattern allows routing traffic to the same endpoint regardless of the rest of the path.

If there is a specific reason for disallowing this usage, please let me know. However, I believe that allowing this flexibility would be beneficial.

Thank you.