### PR TITLE
Async Agents: set the propper timeouts

### DIFF
--- a/async/asyncagent.go
+++ b/async/asyncagent.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
-
  */
 package async
 
@@ -66,8 +65,15 @@ func (a AgentStarter) Start(
 
 		logger.Debug(fmt.Sprintf("[SERVICE: AsyncAgent][%s] Starting the async agent", agent.Name))
 
+		for i := range agent.Backend {
+			b := agent.Backend[i]
+			b.Timeout = agent.Consumer.Timeout
+			agent.Backend[i] = b
+		}
+
 		endpoint := &config.EndpointConfig{
 			Endpoint:    agent.Name,
+			Timeout:     agent.Consumer.Timeout,
 			Backend:     agent.Backend,
 			ExtraConfig: agent.ExtraConfig,
 		}


### PR DESCRIPTION
set the timeouts for the internal endpoint and backend(s)