### PR TITLE
Support multiple certs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -303,19 +303,26 @@ type Plugin struct {
 	Pattern string `mapstructure:"pattern"`
 }
 
+// TLSKeyPair contains a pair of public and private keys
+type TLSKeyPair struct {
+	PublicKey  string `mapstructure:"public_key"`
+	PrivateKey string `mapstructure:"private_key"`
+}
+
 // TLS defines the configuration params for enabling TLS (HTTPS & HTTP/2) at the router layer
 type TLS struct {
-	IsDisabled               bool     `mapstructure:"disabled"`
-	PublicKey                string   `mapstructure:"public_key"`
-	PrivateKey               string   `mapstructure:"private_key"`
-	CaCerts                  []string `mapstructure:"ca_certs"`
-	MinVersion               string   `mapstructure:"min_version"`
-	MaxVersion               string   `mapstructure:"max_version"`
-	CurvePreferences         []uint16 `mapstructure:"curve_preferences"`
-	PreferServerCipherSuites bool     `mapstructure:"prefer_server_cipher_suites"`
-	CipherSuites             []uint16 `mapstructure:"cipher_suites"`
-	EnableMTLS               bool     `mapstructure:"enable_mtls"`
-	DisableSystemCaPool      bool     `mapstructure:"disable_system_ca_pool"`
+	IsDisabled               bool         `mapstructure:"disabled"`
+	PublicKey                string       `mapstructure:"public_key"`
+	PrivateKey               string       `mapstructure:"private_key"`
+	CaCerts                  []string     `mapstructure:"ca_certs"`
+	MinVersion               string       `mapstructure:"min_version"`
+	MaxVersion               string       `mapstructure:"max_version"`
+	CurvePreferences         []uint16     `mapstructure:"curve_preferences"`
+	PreferServerCipherSuites bool         `mapstructure:"prefer_server_cipher_suites"`
+	CipherSuites             []uint16     `mapstructure:"cipher_suites"`
+	EnableMTLS               bool         `mapstructure:"enable_mtls"`
+	DisableSystemCaPool      bool         `mapstructure:"disable_system_ca_pool"`
+	Keys                     []TLSKeyPair `mapstructure:"keys"`
 }
 
 // ClientTLS defines the configuration params for an HTTP Client

--- a/config/parser.go
+++ b/config/parser.go
@@ -213,10 +213,7 @@ func (p *parseableServiceConfig) normalize() ServiceConfig {
 			DisableSystemCaPool:      p.TLS.DisableSystemCaPool,
 		}
 		for _, k := range p.TLS.Keys {
-			cfg.TLS.Keys = append(cfg.TLS.Keys, TLSKeyPair{
-				PublicKey:  k.PublicKey,
-				PrivateKey: k.PrivateKey,
-			})
+			cfg.TLS.Keys = append(cfg.TLS.Keys, TLSKeyPair(k))
 		}
 	}
 	if p.ClientTLS != nil {

--- a/config/parser.go
+++ b/config/parser.go
@@ -212,6 +212,12 @@ func (p *parseableServiceConfig) normalize() ServiceConfig {
 			EnableMTLS:               p.TLS.EnableMTLS,
 			DisableSystemCaPool:      p.TLS.DisableSystemCaPool,
 		}
+		for _, k := range p.TLS.Keys {
+			cfg.TLS.Keys = append(cfg.TLS.Keys, TLSKeyPair{
+				PublicKey:  k.PublicKey,
+				PrivateKey: k.PrivateKey,
+			})
+		}
 	}
 	if p.ClientTLS != nil {
 		cfg.ClientTLS = &ClientTLS{
@@ -244,18 +250,24 @@ func (p *parseableServiceConfig) normalize() ServiceConfig {
 	return cfg
 }
 
+type parseableTLSKeyPair struct {
+	PublicKey  string `json:"public_key"`
+	PrivateKey string `json:"private_key"`
+}
+
 type parseableTLS struct {
-	IsDisabled               bool     `json:"disabled"`
-	PublicKey                string   `json:"public_key"`
-	PrivateKey               string   `json:"private_key"`
-	CaCerts                  []string `json:"ca_certs"`
-	MinVersion               string   `json:"min_version"`
-	MaxVersion               string   `json:"max_version"`
-	CurvePreferences         []uint16 `json:"curve_preferences"`
-	PreferServerCipherSuites bool     `json:"prefer_server_cipher_suites"`
-	CipherSuites             []uint16 `json:"cipher_suites"`
-	EnableMTLS               bool     `json:"enable_mtls"`
-	DisableSystemCaPool      bool     `json:"disable_system_ca_pool"`
+	IsDisabled               bool                  `json:"disabled"`
+	PublicKey                string                `json:"public_key"`
+	PrivateKey               string                `json:"private_key"`
+	CaCerts                  []string              `json:"ca_certs"`
+	MinVersion               string                `json:"min_version"`
+	MaxVersion               string                `json:"max_version"`
+	CurvePreferences         []uint16              `json:"curve_preferences"`
+	PreferServerCipherSuites bool                  `json:"prefer_server_cipher_suites"`
+	CipherSuites             []uint16              `json:"cipher_suites"`
+	EnableMTLS               bool                  `json:"enable_mtls"`
+	DisableSystemCaPool      bool                  `json:"disable_system_ca_pool"`
+	Keys                     []parseableTLSKeyPair `json:"keys"`
 }
 
 type parseableClientTLS struct {

--- a/transport/http/server/server_test.go
+++ b/transport/http/server/server_test.go
@@ -527,18 +527,22 @@ func TestRunServer_MultipleTLS(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	resp, err = client.Get(fmt.Sprintf("https://127.0.0.1:%d", port))
+	_, err = client.Get(fmt.Sprintf("https://127.0.0.1:%d", port))
 	// should fail, because it will be served with cert.pem
 	if err == nil || strings.Contains(err.Error(), "bad certificate") {
 		t.Error("expected to have 'bad certificate' error")
 		return
 	}
 
-	req, _ := http.NewRequest("GET", fmt.Sprintf("https://example.com:%d", port), nil)
-	OverrideHostTransport(client)
+	req, _ := http.NewRequest("GET", fmt.Sprintf("https://example.com:%d", port), http.NoBody)
+	overrideHostTransport(client)
 	resp, err = client.Do(req)
 	if err != nil {
 		t.Error(err)
+		return
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("unexpected status code: %d", resp.StatusCode)
 		return
 	}
 
@@ -548,9 +552,9 @@ func TestRunServer_MultipleTLS(t *testing.T) {
 	}
 }
 
-// OverrideHostTransport subtitutes the actual address that the request will
+// overrideHostTransport subtitutes the actual address that the request will
 // connecto (overriding the dns resolution).
-func OverrideHostTransport(client *http.Client) {
+func overrideHostTransport(client *http.Client) {
 	t := http.DefaultTransport.(*http.Transport).Clone()
 	if client.Transport != nil {
 		if tt, ok := client.Transport.(*http.Transport); ok {

--- a/transport/http/server/tls_test.go
+++ b/transport/http/server/tls_test.go
@@ -23,7 +23,7 @@ type certDef struct {
 }
 
 func (c certDef) Org() string {
-	if len(c.Prefix) == 0 {
+	if c.Prefix == "" {
 		return "Acme Co"
 	}
 	return c.Prefix + " " + "Acme Co"
@@ -84,9 +84,7 @@ func generateNamedCert(hostCert certDef) error {
 			template.IPAddresses = append(template.IPAddresses, ip)
 		}
 	}
-	for _, dname := range hostCert.DNSNames {
-		template.DNSNames = append(template.DNSNames, dname)
-	}
+	template.DNSNames = append(template.DNSNames, hostCert.DNSNames...)
 
 	template.IsCA = true
 	template.KeyUsage |= x509.KeyUsageCertSign


### PR DESCRIPTION
- Add an aditional `keys` field in `TLS` config, to be able to provide several certificates.