### PR TITLE
Skip endpoint if the host list is empty

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -711,6 +711,15 @@ func (e *EndpointConfig) validate() error {
 	return nil
 }
 
+func (e *EndpointConfig) HasHosts() bool {
+	for _, b := range e.Backend {
+		if len(b.Host) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // EndpointMatchError is the error returned by the configuration init process when the endpoint pattern
 // check fails
 type EndpointMatchError struct {

--- a/router/chi/router.go
+++ b/router/chi/router.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
-	Package chi provides some basic implementations for building routers based on go-chi/chi
+Package chi provides some basic implementations for building routers based on go-chi/chi
 */
 package chi
 
@@ -138,6 +138,11 @@ func (r chiRouter) registerKrakendEndpoint(method string, endpoint *config.Endpo
 			r.cfg.Logger.Error(logPrefix, method, "endpoints with sequential proxy enabled only allow a non-GET in the last backend! Ignoring", path)
 			return
 		}
+	}
+
+	if !endpoint.HasHosts() {
+		r.cfg.Logger.Warning(logPrefix, "[ENDPOINT:", path, "] Could not find any valid backend host, skipping")
+		return
 	}
 
 	switch method {

--- a/router/chi/router_test.go
+++ b/router/chi/router_test.go
@@ -42,7 +42,9 @@ func TestDefaultFactory_ok(t *testing.T) {
 	expectedBody := "{\"supu\":\"tupu\"}"
 
 	serviceCfg := config.ServiceConfig{
-		Port: 8062,
+		Port:    8062,
+		Version: 3,
+		Host:    []string{"http://example.com"},
 		Endpoints: []*config.EndpointConfig{
 			{
 				Endpoint: "/get",
@@ -93,6 +95,10 @@ func TestDefaultFactory_ok(t *testing.T) {
 				},
 			},
 		},
+	}
+
+	if err = serviceCfg.Init(); err != nil {
+		t.Errorf("Error during the config init: %s\n", err.Error())
 	}
 
 	go func() { r.Run(serviceCfg) }()
@@ -176,11 +182,10 @@ func TestDefaultFactory_ko(t *testing.T) {
 				Backend:  []*config.Backend{},
 			},
 			{
-				Endpoint: "/also-ignored",
-				Method:   "PUT",
+				Endpoint: "/no-hosts-ignored",
+				Method:   "GET",
 				Backend: []*config.Backend{
-					{},
-					{},
+					{Host: []string{}},
 				},
 			},
 		},
@@ -193,7 +198,7 @@ func TestDefaultFactory_ko(t *testing.T) {
 	for _, subject := range [][]string{
 		{"GET", "ignored"},
 		{"GET", "empty"},
-		{"PUT", "also-ignored"},
+		{"GET", "no-hosts-ignored"},
 	} {
 		req, _ := http.NewRequest(subject[0], fmt.Sprintf("http://127.0.0.1:8063/%s", subject[1]), http.NoBody)
 		req.Header.Set("Content-Type", "application/json")

--- a/router/gin/router.go
+++ b/router/gin/router.go
@@ -154,6 +154,11 @@ func (r ginRouter) registerKrakendEndpoint(rg *gin.RouterGroup, method string, e
 		}
 	}
 
+	if !e.HasHosts() {
+		r.cfg.Logger.Warning(logPrefix, "[ENDPOINT:", path, "] Could not find any valid backend host, skipping")
+		return
+	}
+
 	switch method {
 	case http.MethodGet:
 		rg.GET(path, h)

--- a/router/gin/router_test.go
+++ b/router/gin/router_test.go
@@ -42,7 +42,9 @@ func TestDefaultFactory_ok(t *testing.T) {
 	expectedBody := "{\"supu\":\"tupu\"}"
 
 	serviceCfg := config.ServiceConfig{
-		Port: 8072,
+		Port:    8072,
+		Version: 3,
+		Host:    []string{"http://example.com"},
 		Endpoints: []*config.EndpointConfig{
 			{
 				Endpoint: "/some",
@@ -90,6 +92,10 @@ func TestDefaultFactory_ok(t *testing.T) {
 				"auto_options": true,
 			},
 		},
+	}
+
+	if err = serviceCfg.Init(); err != nil {
+		t.Errorf("Error during the config init: %s\n", err.Error())
 	}
 
 	go func() { r.Run(serviceCfg) }()
@@ -170,7 +176,7 @@ func TestDefaultFactory_ko(t *testing.T) {
 				Endpoint: "/ignored",
 				Method:   "GETTT",
 				Backend: []*config.Backend{
-					{},
+					{Host: []string{"http://example.com"}},
 				},
 			},
 			{
@@ -179,11 +185,10 @@ func TestDefaultFactory_ko(t *testing.T) {
 				Backend:  []*config.Backend{},
 			},
 			{
-				Endpoint: "/also-ignored",
-				Method:   "PUT",
+				Endpoint: "/no-hosts-ignored",
+				Method:   "GET",
 				Backend: []*config.Backend{
-					{},
-					{},
+					{Host: []string{}},
 				},
 			},
 		},
@@ -196,7 +201,7 @@ func TestDefaultFactory_ko(t *testing.T) {
 	for _, subject := range [][]string{
 		{"GET", "ignored"},
 		{"GET", "empty"},
-		{"PUT", "also-ignored"},
+		{"GET", "no-hosts-ignored"},
 	} {
 		req, _ := http.NewRequest(subject[0], fmt.Sprintf("http://127.0.0.1:8073/%s", subject[1]), http.NoBody)
 		req.Header.Set("Content-Type", "application/json")

--- a/router/httptreemux/router_test.go
+++ b/router/httptreemux/router_test.go
@@ -38,7 +38,9 @@ func TestDefaultFactory_ok(t *testing.T) {
 	expectedBody := "{\"supu\":\"tupu\"}"
 
 	serviceCfg := config.ServiceConfig{
-		Port: 8082,
+		Port:    8082,
+		Host:    []string{"http://example.com"},
+		Version: 3,
 		Endpoints: []*config.EndpointConfig{
 			{
 				Endpoint: "/get/:id",
@@ -81,6 +83,10 @@ func TestDefaultFactory_ok(t *testing.T) {
 				},
 			},
 		},
+	}
+
+	if err = serviceCfg.Init(); err != nil {
+		t.Errorf("Error during the config init: %s\n", err.Error())
 	}
 
 	go func() { r.Run(serviceCfg) }()
@@ -157,11 +163,10 @@ func TestDefaultFactory_ko(t *testing.T) {
 				Backend:  []*config.Backend{},
 			},
 			{
-				Endpoint: "/also-ignored",
-				Method:   "PUT",
+				Endpoint: "/no-hosts-ignored",
+				Method:   "GET",
 				Backend: []*config.Backend{
-					{},
-					{},
+					{Host: []string{}},
 				},
 			},
 		},
@@ -174,7 +179,7 @@ func TestDefaultFactory_ko(t *testing.T) {
 	for _, subject := range [][]string{
 		{"GET", "ignored"},
 		{"GET", "empty"},
-		{"PUT", "also-ignored"},
+		{"GET", "no-hosts-ignored"},
 	} {
 		req, _ := http.NewRequest(subject[0], fmt.Sprintf("http://127.0.0.1:8083/%s", subject[1]), http.NoBody)
 		req.Header.Set("Content-Type", "application/json")
@@ -275,10 +280,4 @@ type erroredProxyFactory struct {
 
 func (e erroredProxyFactory) New(_ *config.EndpointConfig) (proxy.Proxy, error) {
 	return proxy.NoopProxy, e.Error
-}
-
-type identityMiddleware struct{}
-
-func (identityMiddleware) Handler(h http.Handler) http.Handler {
-	return h
 }

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -165,6 +165,11 @@ func (r httpRouter) registerKrakendEndpoint(method string, endpoint *config.Endp
 		}
 	}
 
+	if !endpoint.HasHosts() {
+		r.cfg.Logger.Warning(logPrefix, "[ENDPOINT:", path, "] Could not find any valid backend host, skipping")
+		return
+	}
+
 	switch method {
 	case http.MethodGet:
 	case http.MethodPost:

--- a/router/mux/router_test.go
+++ b/router/mux/router_test.go
@@ -41,7 +41,9 @@ func TestDefaultFactory_ok(t *testing.T) {
 	expectedBody := "{\"supu\":\"tupu\"}"
 
 	serviceCfg := config.ServiceConfig{
-		Port: 8062,
+		Port:    8062,
+		Version: 3,
+		Host:    []string{"http://example.com"},
 		Endpoints: []*config.EndpointConfig{
 			{
 				Endpoint: "/get",
@@ -92,6 +94,10 @@ func TestDefaultFactory_ok(t *testing.T) {
 				},
 			},
 		},
+	}
+
+	if err = serviceCfg.Init(); err != nil {
+		t.Errorf("Error during the config init: %s\n", err.Error())
 	}
 
 	go func() { r.Run(serviceCfg) }()
@@ -174,6 +180,13 @@ func TestDefaultFactory_ko(t *testing.T) {
 				Method:   "GETTT",
 				Backend:  []*config.Backend{},
 			},
+			{
+				Endpoint: "/no-hosts-ignored",
+				Method:   "GET",
+				Backend: []*config.Backend{
+					{Host: []string{}},
+				},
+			},
 		},
 	}
 
@@ -184,7 +197,7 @@ func TestDefaultFactory_ko(t *testing.T) {
 	for _, subject := range [][]string{
 		{"GET", "ignored"},
 		{"GET", "empty"},
-		{"PUT", "also-ignored"},
+		{"GET", "no-hosts-ignored"},
 	} {
 		req, _ := http.NewRequest(subject[0], fmt.Sprintf("http://127.0.0.1:8063/%s", subject[1]), http.NoBody)
 		req.Header.Set("Content-Type", "application/json")

--- a/router/negroni/router_test.go
+++ b/router/negroni/router_test.go
@@ -40,7 +40,9 @@ func TestDefaultFactory_ok(t *testing.T) {
 	expectedBody := "{\"supu\":\"tupu\"}"
 
 	serviceCfg := config.ServiceConfig{
-		Port: 8052,
+		Port:    8052,
+		Version: 3,
+		Host:    []string{"http://example.com"},
 		Endpoints: []*config.EndpointConfig{
 			{
 				Endpoint: "/get/{id}",
@@ -83,6 +85,10 @@ func TestDefaultFactory_ok(t *testing.T) {
 				},
 			},
 		},
+	}
+
+	if err = serviceCfg.Init(); err != nil {
+		t.Errorf("Error during the config init: %s\n", err.Error())
 	}
 
 	go func() { r.Run(serviceCfg) }()
@@ -144,7 +150,9 @@ func TestDefaultFactory_middlewares(t *testing.T) {
 	expectedBody := "{\"supu\":\"tupu\"}"
 
 	serviceCfg := config.ServiceConfig{
-		Port: 8090,
+		Port:    8090,
+		Version: 3,
+		Host:    []string{"http://example.com"},
 		Endpoints: []*config.EndpointConfig{
 			{
 				Endpoint: "/get/{id}",
@@ -155,6 +163,10 @@ func TestDefaultFactory_middlewares(t *testing.T) {
 				},
 			},
 		},
+	}
+
+	if err = serviceCfg.Init(); err != nil {
+		t.Errorf("Error during the config init: %s\n", err.Error())
 	}
 
 	go func() { r.Run(serviceCfg) }()
@@ -235,11 +247,10 @@ func TestDefaultFactory_ko(t *testing.T) {
 				Backend:  []*config.Backend{},
 			},
 			{
-				Endpoint: "/also-ignored",
-				Method:   "PUT",
+				Endpoint: "/no-hosts-ignored",
+				Method:   "GET",
 				Backend: []*config.Backend{
-					{},
-					{},
+					{Host: []string{}},
 				},
 			},
 		},
@@ -252,7 +263,7 @@ func TestDefaultFactory_ko(t *testing.T) {
 	for _, subject := range [][]string{
 		{"GET", "ignored"},
 		{"GET", "empty"},
-		{"PUT", "also-ignored"},
+		{"GET", "no-hosts-ignored"},
 	} {
 		req, _ := http.NewRequest(subject[0], fmt.Sprintf("http://127.0.0.1:8053/%s", subject[1]), http.NoBody)
 		req.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
Fixes https://github.com/krakend/krakend-ce/issues/948

Router endpoint registration is skipped if the `host` list is empty **after config initialization**

### Example
**Config file**
```
{
  "$schema": "https://www.krakend.io/schema/krakend.json",
  "version": 3,
  "echo_endpoint": true,
  "endpoints": [
    {
      "endpoint": "/some-api",
      "backend": [
        {
          "url_pattern": "/__echo",
          "host": [
            "http://localhost:8080"
          ]
        }
      ]
    },
    {
      "endpoint": "/api-without-backend",
      "backend": [
        {
          "url_pattern": "/__echo",
          "host": []
        }
      ]
    }
  ]
}
```

**Startup warning**
```
...
2024/12/16 11:56:08 KRAKEND WARNING: [SERVICE: Gin] [ENDPOINT: /api-without-backend ] Could not find any valid backend host, skipping
...
```

And the endpoint is not registered, thus a 404 is returned when requesting it
```
$ curl http://localhost:8080/api-without-backend
404 page not found
```