### PR TITLE
Validate backend host count on config init

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -243,7 +243,7 @@ func TestConfig_initAtLeastOneHost(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	if hash != "JmPNpF4R859GgtXPOZNVhrsY6ByFq9CgE8or8+Zy45c=" {
+	if hash != "/2xqGWkemKmpd/66klm9k879UHrH5emSDfD80zJwSAs=" {
 		t.Errorf("unexpected hash: %s", hash)
 	}
 }

--- a/router/chi/router_test.go
+++ b/router/chi/router_test.go
@@ -175,14 +175,6 @@ func TestDefaultFactory_ko(t *testing.T) {
 				Method:   "GETTT",
 				Backend:  []*config.Backend{},
 			},
-			{
-				Endpoint: "/also-ignored",
-				Method:   "PUT",
-				Backend: []*config.Backend{
-					{},
-					{},
-				},
-			},
 		},
 	}
 
@@ -193,7 +185,6 @@ func TestDefaultFactory_ko(t *testing.T) {
 	for _, subject := range [][]string{
 		{"GET", "ignored"},
 		{"GET", "empty"},
-		{"PUT", "also-ignored"},
 	} {
 		req, _ := http.NewRequest(subject[0], fmt.Sprintf("http://127.0.0.1:8063/%s", subject[1]), http.NoBody)
 		req.Header.Set("Content-Type", "application/json")

--- a/router/gin/router_test.go
+++ b/router/gin/router_test.go
@@ -178,14 +178,6 @@ func TestDefaultFactory_ko(t *testing.T) {
 				Method:   "GETTT",
 				Backend:  []*config.Backend{},
 			},
-			{
-				Endpoint: "/also-ignored",
-				Method:   "PUT",
-				Backend: []*config.Backend{
-					{},
-					{},
-				},
-			},
 		},
 	}
 
@@ -196,7 +188,6 @@ func TestDefaultFactory_ko(t *testing.T) {
 	for _, subject := range [][]string{
 		{"GET", "ignored"},
 		{"GET", "empty"},
-		{"PUT", "also-ignored"},
 	} {
 		req, _ := http.NewRequest(subject[0], fmt.Sprintf("http://127.0.0.1:8073/%s", subject[1]), http.NoBody)
 		req.Header.Set("Content-Type", "application/json")

--- a/router/gorilla/router_test.go
+++ b/router/gorilla/router_test.go
@@ -156,14 +156,6 @@ func TestDefaultFactory_ko(t *testing.T) {
 				Method:   "GETTT",
 				Backend:  []*config.Backend{},
 			},
-			{
-				Endpoint: "/also-ignored",
-				Method:   "PUT",
-				Backend: []*config.Backend{
-					{},
-					{},
-				},
-			},
 		},
 	}
 
@@ -174,7 +166,6 @@ func TestDefaultFactory_ko(t *testing.T) {
 	for _, subject := range [][]string{
 		{"GET", "ignored"},
 		{"GET", "empty"},
-		{"PUT", "also-ignored"},
 	} {
 		req, _ := http.NewRequest(subject[0], fmt.Sprintf("http://127.0.0.1:8083/%s", subject[1]), http.NoBody)
 		req.Header.Set("Content-Type", "application/json")

--- a/router/httptreemux/router_test.go
+++ b/router/httptreemux/router_test.go
@@ -156,14 +156,6 @@ func TestDefaultFactory_ko(t *testing.T) {
 				Method:   "GETTT",
 				Backend:  []*config.Backend{},
 			},
-			{
-				Endpoint: "/also-ignored",
-				Method:   "PUT",
-				Backend: []*config.Backend{
-					{},
-					{},
-				},
-			},
 		},
 	}
 
@@ -174,7 +166,6 @@ func TestDefaultFactory_ko(t *testing.T) {
 	for _, subject := range [][]string{
 		{"GET", "ignored"},
 		{"GET", "empty"},
-		{"PUT", "also-ignored"},
 	} {
 		req, _ := http.NewRequest(subject[0], fmt.Sprintf("http://127.0.0.1:8083/%s", subject[1]), http.NoBody)
 		req.Header.Set("Content-Type", "application/json")
@@ -275,10 +266,4 @@ type erroredProxyFactory struct {
 
 func (e erroredProxyFactory) New(_ *config.EndpointConfig) (proxy.Proxy, error) {
 	return proxy.NoopProxy, e.Error
-}
-
-type identityMiddleware struct{}
-
-func (identityMiddleware) Handler(h http.Handler) http.Handler {
-	return h
 }

--- a/router/mux/router_test.go
+++ b/router/mux/router_test.go
@@ -184,7 +184,6 @@ func TestDefaultFactory_ko(t *testing.T) {
 	for _, subject := range [][]string{
 		{"GET", "ignored"},
 		{"GET", "empty"},
-		{"PUT", "also-ignored"},
 	} {
 		req, _ := http.NewRequest(subject[0], fmt.Sprintf("http://127.0.0.1:8063/%s", subject[1]), http.NoBody)
 		req.Header.Set("Content-Type", "application/json")

--- a/router/negroni/router_test.go
+++ b/router/negroni/router_test.go
@@ -234,14 +234,6 @@ func TestDefaultFactory_ko(t *testing.T) {
 				Method:   "GETTT",
 				Backend:  []*config.Backend{},
 			},
-			{
-				Endpoint: "/also-ignored",
-				Method:   "PUT",
-				Backend: []*config.Backend{
-					{},
-					{},
-				},
-			},
 		},
 	}
 
@@ -252,7 +244,6 @@ func TestDefaultFactory_ko(t *testing.T) {
 	for _, subject := range [][]string{
 		{"GET", "ignored"},
 		{"GET", "empty"},
-		{"PUT", "also-ignored"},
 	} {
 		req, _ := http.NewRequest(subject[0], fmt.Sprintf("http://127.0.0.1:8053/%s", subject[1]), http.NoBody)
 		req.Header.Set("Content-Type", "application/json")
@@ -362,10 +353,4 @@ type erroredProxyFactory struct {
 
 func (e erroredProxyFactory) New(_ *config.EndpointConfig) (proxy.Proxy, error) {
 	return proxy.NoopProxy, e.Error
-}
-
-type identityMiddleware struct{}
-
-func (identityMiddleware) Handler(h http.Handler) http.Handler {
-	return h
 }


### PR DESCRIPTION
Fixes https://github.com/krakend/krakend-ce/issues/948

Config initialization fails if there's an endpoint without any backend hosts

### Example
**Config file**
```
{
  "$schema": "https://www.krakend.io/schema/krakend.json",
  "version": 3,
  "echo_endpoint": true,
  "endpoints": [
    {
      "endpoint": "/some-api",
      "backend": [
        {
          "url_pattern": "/__echo",
          "host": [
            "http://localhost:8080"
          ]
        }
      ]
    },
    {
      "endpoint": "/api-without-backend",
      "backend": [
        {
          "url_pattern": "/__echo",
          "host": []
        }
      ]
    }
  ]
}
```

**Config check**
```
$ krakend check -c ./krakend.json 
Parsing configuration file: /home/dae/work/krakend/configs/ce-issue-948/krakend.json
ERROR parsing the configuration file:	'/home/dae/work/krakend/configs/ce-issue-948/krakend.json': can't register 'GET /api-without-backend' endpoint, it doesn't have any host

exit status 1
```

**Startup**
```
$ krakend run -c ./krakend.json 
ERROR parsing the configuration file: '/home/dae/work/krakend/configs/ce-issue-948/krakend.json': can't register 'GET /api-without-backend' endpoint, it doesn't have any host
exit status 255
```