### PR TITLE
[WiP] Mw plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ generate:
 	go build -buildmode=plugin -o ./transport/http/server/plugin/tests/lura-server-example.so ./transport/http/server/plugin/tests
 	go build -buildmode=plugin -o ./proxy/plugin/tests/lura-request-modifier-example.so ./proxy/plugin/tests/logger
 	go build -buildmode=plugin -o ./proxy/plugin/tests/lura-error-example.so ./proxy/plugin/tests/error
+	go build -buildmode=plugin -o ./proxy/plugin/tests/lura-middleware-example.so ./proxy/plugin/tests/middleware
 
 test: generate
 	go test -cover -race ./...

--- a/proxy/factory.go
+++ b/proxy/factory.go
@@ -69,6 +69,7 @@ func (pf defaultFactory) New(cfg *config.EndpointConfig) (p Proxy, err error) {
 	}
 
 	p = NewPluginMiddleware(pf.logger, cfg)(p)
+	p = NewMwPluginMiddleware(pf.logger, cfg)(p)
 	p = NewStaticMiddleware(pf.logger, cfg)(p)
 	return
 }
@@ -90,6 +91,7 @@ func (pf defaultFactory) newSingle(cfg *config.EndpointConfig) (Proxy, error) {
 func (pf defaultFactory) newStack(backend *config.Backend) (p Proxy) {
 	p = pf.backendFactory(backend)
 	p = NewBackendPluginMiddleware(pf.logger, backend)(p)
+	p = NewBackendMwPluginMiddleware(pf.logger, backend)(p)
 	p = NewGraphQLMiddleware(pf.logger, backend)(p)
 	p = NewFilterHeadersMiddleware(pf.logger, backend)(p)
 	p = NewFilterQueryStringsMiddleware(pf.logger, backend)(p)

--- a/proxy/plugin.go
+++ b/proxy/plugin.go
@@ -24,7 +24,7 @@ func NewPluginMiddleware(logger logging.Logger, endpoint *config.EndpointConfig)
 		return emptyMiddlewareFallback(logger)
 	}
 
-	return newPluginMiddleware(logger, "ENDPOINT", endpoint.Endpoint, cfg)
+	return newModifierPluginMiddleware(logger, "ENDPOINT", endpoint.Endpoint, cfg)
 }
 
 // NewBackendPluginMiddleware returns a backend middleware wrapped (if required) with the plugin middleware.
@@ -38,11 +38,11 @@ func NewBackendPluginMiddleware(logger logging.Logger, remote *config.Backend) M
 		return emptyMiddlewareFallback(logger)
 	}
 
-	return newPluginMiddleware(logger, "BACKEND",
+	return newModifierPluginMiddleware(logger, "BACKEND",
 		fmt.Sprintf("%s %s -> %s", remote.ParentEndpointMethod, remote.ParentEndpoint, remote.URLPattern), cfg)
 }
 
-func newPluginMiddleware(logger logging.Logger, tag, pattern string, cfg map[string]interface{}) Middleware {
+func newModifierPluginMiddleware(logger logging.Logger, tag, pattern string, cfg map[string]interface{}) Middleware {
 	plugins, ok := cfg["name"].([]interface{})
 	if !ok {
 		return emptyMiddlewareFallback(logger)

--- a/proxy/plugin/middleware.go
+++ b/proxy/plugin/middleware.go
@@ -16,7 +16,7 @@ const MiddlewareNamespace = "github.com/devopsfaith/krakend/proxy/plugin/middlew
 // MiddlewareFactory is function that, given an extra_config and a middleware returns another middleware with custom logic wrapping the one passed as argument
 type MiddlewareFactory func(map[string]interface{}, func(context.Context, interface{}) (interface{}, error)) func(context.Context, interface{}) (interface{}, error)
 
-// RegisterModifier registers the injected modifier factory with the given name at the selected namespace
+// RegisterMiddleware registers the injected modifier factory with the given name at the selected namespace
 func RegisterMiddleware(
 	name string,
 	middlewareFactory func(map[string]interface{}, func(context.Context, interface{}) (interface{}, error)) func(context.Context, interface{}) (interface{}, error),

--- a/proxy/plugin/middleware.go
+++ b/proxy/plugin/middleware.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/luraproject/lura/v2/logging"
+	luraplugin "github.com/luraproject/lura/v2/plugin"
+)
+
+// MiddlewareNamespace is the internal namespace for the register to be used with middlewares
+const MiddlewareNamespace = "github.com/devopsfaith/krakend/proxy/plugin/middleware"
+
+// MiddlewareFactory is function that, given an extra_config and a middleware returns another middleware with custom logic wrapping the one passed as argument
+type MiddlewareFactory func(map[string]interface{}, func(context.Context, interface{}) (interface{}, error)) func(context.Context, interface{}) (interface{}, error)
+
+// RegisterModifier registers the injected modifier factory with the given name at the selected namespace
+func RegisterMiddleware(
+	name string,
+	middlewareFactory func(map[string]interface{}, func(context.Context, interface{}) (interface{}, error)) func(context.Context, interface{}) (interface{}, error),
+) {
+	pluginRegister.Register(MiddlewareNamespace, name, middlewareFactory)
+}
+
+// MiddlewareRegisterer defines the interface for the plugins to expose in order to be able to be loaded/registered
+type MiddlewareRegisterer interface {
+	RegisterMiddlewares(func(
+		name string,
+		middlewareFactory func(map[string]interface{}, func(context.Context, interface{}) (interface{}, error)) func(context.Context, interface{}) (interface{}, error),
+	))
+}
+
+type RegisterMiddlewareFunc func(
+	name string,
+	middlewareFactory func(map[string]interface{}, func(context.Context, interface{}) (interface{}, error)) func(context.Context, interface{}) (interface{}, error),
+)
+
+func GetMiddleware(name string) (MiddlewareFactory, bool) {
+	r, ok := pluginRegister.Get(MiddlewareNamespace)
+	if !ok {
+		return nil, ok
+	}
+	m, ok := r.Get(name)
+	if !ok {
+		return nil, ok
+	}
+	res, ok := m.(func(map[string]interface{}, func(context.Context, interface{}) (interface{}, error)) func(context.Context, interface{}) (interface{}, error))
+	if !ok {
+		return nil, ok
+	}
+	return MiddlewareFactory(res), ok
+}
+
+func LoadMiddlewares(ctx context.Context, path, pattern string, rmf RegisterMiddlewareFunc, logger logging.Logger) (int, error) {
+	plugins, err := luraplugin.Scan(path, pattern)
+	if err != nil {
+		return 0, err
+	}
+
+	var errors []error
+
+	loadedPlugins := 0
+	for k, pluginName := range plugins {
+		if err := openMiddleware(ctx, pluginName, rmf, logger); err != nil {
+			errors = append(errors, fmt.Errorf("plugin #%d (%s): %s", k, pluginName, err.Error()))
+			continue
+		}
+		loadedPlugins++
+	}
+
+	if len(errors) > 0 {
+		return loadedPlugins, loaderError{errors: errors}
+	}
+
+	return loadedPlugins, nil
+}
+
+func openMiddleware(ctx context.Context, pluginName string, rmf RegisterMiddlewareFunc, logger logging.Logger) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var ok bool
+			err, ok = r.(error)
+			if !ok {
+				err = fmt.Errorf("%v", r)
+			}
+		}
+	}()
+
+	p, err := pluginOpener(pluginName)
+	if err != nil {
+		return err
+	}
+	r, err := p.Lookup("MiddlewareRegisterer")
+	if err != nil {
+		return err
+	}
+	registerer, ok := r.(MiddlewareRegisterer)
+	if !ok {
+		return fmt.Errorf("middleware plugin loader: unknown type")
+	}
+
+	registerExtraComponents(r, ctx, logger)
+
+	registerer.RegisterMiddlewares(rmf)
+	return
+}

--- a/proxy/plugin/middleware_test.go
+++ b/proxy/plugin/middleware_test.go
@@ -1,0 +1,191 @@
+//go:build integration || !race
+// +build integration !race
+
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/luraproject/lura/v2/logging"
+)
+
+func ExampleLoadMiddlewares() {
+	var data []byte
+
+	buf := bytes.NewBuffer(data)
+	logger, err := logging.NewLogger("DEBUG", buf, "")
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	total, err := LoadMiddlewares(context.Background(), "./tests", ".so", RegisterMiddleware, logger)
+	if err != nil {
+		for _, errLine := range strings.Split(err.Error(), "\n") {
+			fmt.Println("'" + errLine + "'")
+		}
+	}
+	if total != 1 {
+		fmt.Printf("unexpected number of loaded plugins!. have %d, want 1\n", total)
+		return
+	}
+
+	mwFactory, ok := GetMiddleware("middleware-plugin-demo")
+	if !ok {
+		fmt.Println("modifier factory not found in the register")
+		return
+	}
+
+	input := requestWrapper{
+		ctx:    context.WithValue(context.Background(), "myCtxKey", "some"),
+		path:   "/bar",
+		method: "GET",
+	}
+
+	modifier := mwFactory(map[string]interface{}{}, func(ctx context.Context, r interface{}) (interface{}, error) {
+		rw, ok := r.(RequestWrapper)
+		if !ok {
+			fmt.Println("unexpected request type")
+			return nil, nil
+		}
+		if path := rw.Path(); path != "/bar/fooo" {
+			fmt.Printf("unexpected path. have %s, want /bar/fooo\n", path)
+		}
+		return responseWrapper{isComplete: true, data: map[string]interface{}{"foo": "bar"}}, nil
+	})
+
+	tmp, err := modifier(context.Background(), input)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+
+	output, ok := tmp.(ResponseWrapper)
+	if !ok {
+		fmt.Println("unexpected result type")
+		return
+	}
+
+	fmt.Printf("%+v\n", output.Data())
+
+	lines := strings.Split(buf.String(), "\n")
+	for i := range lines[:len(lines)-1] {
+		fmt.Println(lines[i][21:])
+	}
+
+	// output:
+	// 'plugin loader found 2 error(s): '
+	// 'plugin #0 (tests/lura-error-example.so): plugin: symbol MiddlewareRegisterer not found in plugin github.com/luraproject/lura/v2/proxy/plugin/tests/error'
+	// 'plugin #2 (tests/lura-request-modifier-example.so): plugin: symbol MiddlewareRegisterer not found in plugin github.com/luraproject/lura/v2/proxy/plugin/tests/logger'
+	// map[extra:true foo:bar]
+	// DEBUG: [PLUGIN: middleware-plugin-demo] Logger loaded
+	// DEBUG: [PLUGIN: middleware-plugin-demo] Context loaded
+	// DEBUG: [PLUGIN: middleware-plugin-demo] Middleware injected
+
+}
+
+func TestLoadMiddlewares(t *testing.T) {
+	total, err := LoadMiddlewares(context.Background(), "./tests", ".so", RegisterMiddleware, logging.NoOp)
+	if err == nil {
+		t.Error("an error was expected")
+		return
+	}
+
+	expectedErrorMsg := `plugin loader found 2 error(s): 
+plugin #0 (tests/lura-error-example.so): plugin: symbol MiddlewareRegisterer not found in plugin github.com/luraproject/lura/v2/proxy/plugin/tests/error
+plugin #2 (tests/lura-request-modifier-example.so): plugin: symbol MiddlewareRegisterer not found in plugin github.com/luraproject/lura/v2/proxy/plugin/tests/logger`
+
+	if errMsg := err.Error(); errMsg != expectedErrorMsg {
+		t.Errorf("unexpected error: %s", errMsg)
+	}
+
+	if total != 1 {
+		t.Errorf("unexpected number of loaded plugins!. have %d, want 1", total)
+	}
+
+	mwFactory, ok := GetMiddleware("middleware-plugin-demo")
+	if !ok {
+		t.Error("middleware factory not found in the register")
+		return
+	}
+
+	var wasNextExecuted bool
+
+	modifier := mwFactory(map[string]interface{}{}, func(ctx context.Context, r interface{}) (interface{}, error) {
+		wasNextExecuted = true
+		rw, ok := r.(RequestWrapper)
+		if !ok {
+			t.Error("unexpected result type")
+			return nil, nil
+		}
+		if path := rw.Path(); path != "/bar/fooo" {
+			t.Errorf("unexpected result path. have %s, want /bar/fooo", path)
+		}
+		return responseWrapper{isComplete: true, data: map[string]interface{}{"foo": "bar"}}, nil
+	})
+
+	req := requestWrapper{ctx: context.WithValue(context.Background(), "myCtxKey", "some"), path: "/bar"}
+
+	tmp, err := modifier(context.Background(), req)
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if !wasNextExecuted {
+		t.Error("the next middleware wasn't executed")
+	}
+
+	output, ok := tmp.(ResponseWrapper)
+	if !ok {
+		t.Error("unexpected result type")
+		return
+	}
+
+	data := output.Data()
+	if v, ok := data["extra"].(bool); !ok || !v {
+		t.Error("wrong extra field in the response data")
+	}
+	if v, ok := data["foo"].(string); !ok || v != "bar" {
+		t.Error("wrong foo field in the response data")
+	}
+}
+
+type ResponseWrapper interface {
+	Data() map[string]interface{}
+	Io() io.Reader
+	IsComplete() bool
+	Headers() map[string][]string
+	StatusCode() int
+}
+
+type metadataWrapper struct {
+	headers    map[string][]string
+	statusCode int
+}
+
+func (m metadataWrapper) Headers() map[string][]string { return m.headers }
+func (m metadataWrapper) StatusCode() int              { return m.statusCode }
+
+type responseWrapper struct {
+	ctx        context.Context
+	request    interface{}
+	data       map[string]interface{}
+	isComplete bool
+	metadata   metadataWrapper
+	io         io.Reader
+}
+
+func (r responseWrapper) Context() context.Context     { return r.ctx }
+func (r responseWrapper) Request() interface{}         { return r.request }
+func (r responseWrapper) Data() map[string]interface{} { return r.data }
+func (r responseWrapper) IsComplete() bool             { return r.isComplete }
+func (r responseWrapper) Io() io.Reader                { return r.io }
+func (r responseWrapper) Headers() map[string][]string { return r.metadata.headers }
+func (r responseWrapper) StatusCode() int              { return r.metadata.statusCode }

--- a/proxy/plugin/modifier.go
+++ b/proxy/plugin/modifier.go
@@ -8,8 +8,6 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"plugin"
-	"strings"
 
 	"github.com/luraproject/lura/v2/logging"
 	luraplugin "github.com/luraproject/lura/v2/plugin"
@@ -17,15 +15,13 @@ import (
 )
 
 const (
-	// Namespace is the namespace for the extra_config section
-	Namespace = "github.com/devopsfaith/krakend/proxy/plugin"
 	// requestNamespace is the internal namespace for the register to be used with request modifiers
 	requestNamespace = "github.com/devopsfaith/krakend/proxy/plugin/request"
 	// responseNamespace is the internal namespace for the register to be used with response modifiers
 	responseNamespace = "github.com/devopsfaith/krakend/proxy/plugin/response"
 )
 
-var modifierRegister = register.New()
+var pluginRegister = register.New()
 
 // ModifierFactory is a function that, given a config passed as a map, returns a modifier
 type ModifierFactory func(map[string]interface{}) func(interface{}) (interface{}, error)
@@ -41,7 +37,7 @@ func GetResponseModifier(name string) (ModifierFactory, bool) {
 }
 
 func getModifier(namespace, name string) (ModifierFactory, bool) {
-	r, ok := modifierRegister.Get(namespace)
+	r, ok := pluginRegister.Get(namespace)
 	if !ok {
 		return nil, ok
 	}
@@ -64,10 +60,10 @@ func RegisterModifier(
 	appliesToResponse bool,
 ) {
 	if appliesToRequest {
-		modifierRegister.Register(requestNamespace, name, modifierFactory)
+		pluginRegister.Register(requestNamespace, name, modifierFactory)
 	}
 	if appliesToResponse {
-		modifierRegister.Register(responseNamespace, name, modifierFactory)
+		pluginRegister.Register(responseNamespace, name, modifierFactory)
 	}
 }
 
@@ -112,15 +108,12 @@ func LoadWithLoggerAndContext(ctx context.Context, path, pattern string, rmf Reg
 	if err != nil {
 		return 0, err
 	}
-	return load(ctx, plugins, rmf, logger)
-}
 
-func load(ctx context.Context, plugins []string, rmf RegisterModifierFunc, logger logging.Logger) (int, error) {
 	var errors []error
 
 	loadedPlugins := 0
 	for k, pluginName := range plugins {
-		if err := open(ctx, pluginName, rmf, logger); err != nil {
+		if err := openModifier(ctx, pluginName, rmf, logger); err != nil {
 			errors = append(errors, fmt.Errorf("plugin #%d (%s): %s", k, pluginName, err.Error()))
 			continue
 		}
@@ -130,10 +123,11 @@ func load(ctx context.Context, plugins []string, rmf RegisterModifierFunc, logge
 	if len(errors) > 0 {
 		return loadedPlugins, loaderError{errors: errors}
 	}
+
 	return loadedPlugins, nil
 }
 
-func open(ctx context.Context, pluginName string, rmf RegisterModifierFunc, logger logging.Logger) (err error) {
+func openModifier(ctx context.Context, pluginName string, rmf RegisterModifierFunc, logger logging.Logger) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			var ok bool
@@ -144,64 +138,21 @@ func open(ctx context.Context, pluginName string, rmf RegisterModifierFunc, logg
 		}
 	}()
 
-	var p Plugin
-	p, err = pluginOpener(pluginName)
+	p, err := pluginOpener(pluginName)
 	if err != nil {
-		return
+		return err
 	}
-	var r interface{}
-	r, err = p.Lookup("ModifierRegisterer")
+	r, err := p.Lookup("ModifierRegisterer")
 	if err != nil {
-		return
+		return err
 	}
 	registerer, ok := r.(Registerer)
 	if !ok {
 		return fmt.Errorf("modifier plugin loader: unknown type")
 	}
 
-	if logger != nil {
-		if lr, ok := r.(LoggerRegisterer); ok {
-			lr.RegisterLogger(logger)
-		}
-	}
-
-	if lr, ok := r.(ContextRegisterer); ok {
-		lr.RegisterContext(ctx)
-	}
+	registerExtraComponents(r, ctx, logger)
 
 	registerer.RegisterModifiers(rmf)
 	return
-}
-
-// Plugin is the interface of the loaded plugins
-type Plugin interface {
-	Lookup(name string) (plugin.Symbol, error)
-}
-
-// pluginOpener keeps the plugin open function in a var for easy testing
-var pluginOpener = defaultPluginOpener
-
-func defaultPluginOpener(name string) (Plugin, error) {
-	return plugin.Open(name)
-}
-
-type loaderError struct {
-	errors []error
-}
-
-// Error implements the error interface
-func (l loaderError) Error() string {
-	msgs := make([]string, len(l.errors))
-	for i, err := range l.errors {
-		msgs[i] = err.Error()
-	}
-	return fmt.Sprintf("plugin loader found %d error(s): \n%s", len(msgs), strings.Join(msgs, "\n"))
-}
-
-func (l loaderError) Len() int {
-	return len(l.errors)
-}
-
-func (l loaderError) Errs() []error {
-	return l.errors
 }

--- a/proxy/plugin/plugin.go
+++ b/proxy/plugin/plugin.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"plugin"
+	"strings"
+
+	"github.com/luraproject/lura/v2/logging"
+)
+
+// Namespace is the namespace for the extra_config section
+const Namespace = "github.com/devopsfaith/krakend/proxy/plugin"
+
+// Plugin is the interface of the loaded plugins
+type Plugin interface {
+	Lookup(name string) (plugin.Symbol, error)
+}
+
+// pluginOpener keeps the plugin open function in a var for easy testing
+var pluginOpener = defaultPluginOpener
+
+func defaultPluginOpener(name string) (Plugin, error) {
+	return plugin.Open(name)
+}
+
+func registerExtraComponents(r plugin.Symbol, ctx context.Context, l logging.Logger) {
+	if l != nil {
+		if lr, ok := r.(LoggerRegisterer); ok {
+			lr.RegisterLogger(l)
+		}
+	}
+
+	if lr, ok := r.(ContextRegisterer); ok {
+		lr.RegisterContext(ctx)
+	}
+}
+
+type loaderError struct {
+	errors []error
+}
+
+// Error implements the error interface
+func (l loaderError) Error() string {
+	msgs := make([]string, len(l.errors))
+	for i, err := range l.errors {
+		msgs[i] = err.Error()
+	}
+	return fmt.Sprintf("plugin loader found %d error(s): \n%s", len(msgs), strings.Join(msgs, "\n"))
+}
+
+func (l loaderError) Len() int {
+	return len(l.errors)
+}
+
+func (l loaderError) Errs() []error {
+	return l.errors
+}

--- a/proxy/plugin/tests/middleware/main.go
+++ b/proxy/plugin/tests/middleware/main.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+)
+
+var MiddlewareRegisterer = registerer("middleware-plugin-demo")
+
+var (
+	logger                Logger          = nil
+	ctx                   context.Context = context.Background()
+	unkownRequestTypeErr                  = errors.New("unknown request type")
+	unkownResponseTypeErr                 = errors.New("unknown response type")
+)
+
+type registerer string
+
+func (r registerer) RegisterMiddlewares(f func(
+	name string,
+	middlewareFactory func(map[string]interface{}, func(context.Context, interface{}) (interface{}, error)) func(context.Context, interface{}) (interface{}, error),
+)) {
+	f(string(r), r.middlewareFactory)
+}
+
+func (r registerer) middlewareFactory(cfg map[string]interface{}, next func(context.Context, interface{}) (interface{}, error)) func(context.Context, interface{}) (interface{}, error) {
+	// TODO: parse the config
+	logger.Debug(fmt.Sprintf("[PLUGIN: %s] Middleware injected", r))
+	return func(ctx context.Context, req interface{}) (interface{}, error) {
+		reqw, ok := req.(RequestWrapper)
+		if !ok {
+			return nil, unkownRequestTypeErr
+		}
+
+		resp, err := next(ctx, requestWrapper{
+			params:  reqw.Params(),
+			headers: reqw.Headers(),
+			body:    reqw.Body(),
+			method:  reqw.Method(),
+			url:     reqw.URL(),
+			query:   reqw.Query(),
+			path:    reqw.Path() + "/fooo",
+		})
+		respw, ok := resp.(ResponseWrapper)
+		if !ok {
+			return nil, unkownResponseTypeErr
+		}
+
+		data := respw.Data()
+		data["extra"] = true
+
+		return responseWrapper{
+			ctx:        respw.Context(),
+			request:    respw.Request(),
+			data:       data,
+			isComplete: respw.IsComplete(),
+			metadata: metadataWrapper{
+				headers:    respw.Headers(),
+				statusCode: respw.StatusCode(),
+			},
+			io: respw.Io(),
+		}, err
+	}
+}
+
+func (r registerer) RegisterLogger(in interface{}) {
+	l, ok := in.(Logger)
+	if !ok {
+		return
+	}
+	logger = l
+	logger.Debug(fmt.Sprintf("[PLUGIN: %s] Logger loaded", r))
+}
+
+func (r registerer) RegisterContext(c context.Context) {
+	ctx = c
+	logger.Debug(fmt.Sprintf("[PLUGIN: %s] Context loaded", r))
+}
+
+func main() {}
+
+type ResponseWrapper interface {
+	Context() context.Context
+	Request() interface{}
+	Data() map[string]interface{}
+	IsComplete() bool
+	Headers() map[string][]string
+	StatusCode() int
+	Io() io.Reader
+}
+
+type RequestWrapper interface {
+	Context() context.Context
+	Params() map[string]string
+	Headers() map[string][]string
+	Body() io.ReadCloser
+	Method() string
+	URL() *url.URL
+	Query() url.Values
+	Path() string
+}
+
+type requestWrapper struct {
+	ctx     context.Context
+	method  string
+	url     *url.URL
+	query   url.Values
+	path    string
+	body    io.ReadCloser
+	params  map[string]string
+	headers map[string][]string
+}
+
+func (r requestWrapper) Context() context.Context     { return r.ctx }
+func (r requestWrapper) Method() string               { return r.method }
+func (r requestWrapper) URL() *url.URL                { return r.url }
+func (r requestWrapper) Query() url.Values            { return r.query }
+func (r requestWrapper) Path() string                 { return r.path }
+func (r requestWrapper) Body() io.ReadCloser          { return r.body }
+func (r requestWrapper) Params() map[string]string    { return r.params }
+func (r requestWrapper) Headers() map[string][]string { return r.headers }
+
+type metadataWrapper struct {
+	headers    map[string][]string
+	statusCode int
+}
+
+func (m metadataWrapper) Headers() map[string][]string { return m.headers }
+func (m metadataWrapper) StatusCode() int              { return m.statusCode }
+
+type responseWrapper struct {
+	ctx        context.Context
+	request    interface{}
+	data       map[string]interface{}
+	isComplete bool
+	metadata   metadataWrapper
+	io         io.Reader
+}
+
+func (r responseWrapper) Context() context.Context     { return r.ctx }
+func (r responseWrapper) Request() interface{}         { return r.request }
+func (r responseWrapper) Data() map[string]interface{} { return r.data }
+func (r responseWrapper) IsComplete() bool             { return r.isComplete }
+func (r responseWrapper) Io() io.Reader                { return r.io }
+func (r responseWrapper) Headers() map[string][]string { return r.metadata.headers }
+func (r responseWrapper) StatusCode() int              { return r.metadata.statusCode }
+
+type Logger interface {
+	Debug(v ...interface{})
+	Info(v ...interface{})
+	Warning(v ...interface{})
+	Error(v ...interface{})
+	Critical(v ...interface{})
+	Fatal(v ...interface{})
+}

--- a/proxy/plugin_middleware.go
+++ b/proxy/plugin_middleware.go
@@ -20,7 +20,7 @@ func NewMwPluginMiddleware(logger logging.Logger, endpoint *config.EndpointConfi
 		return emptyMiddlewareFallback(logger)
 	}
 
-	return newModifierPluginMiddleware(logger, "ENDPOINT", endpoint.Endpoint, cfg)
+	return newMwPluginMiddleware(logger, "ENDPOINT", endpoint.Endpoint, cfg)
 }
 
 // NewBackendMwPluginMiddleware returns a backend middleware wrapped (if required) with the plugin middleware.
@@ -32,7 +32,7 @@ func NewBackendMwPluginMiddleware(logger logging.Logger, remote *config.Backend)
 		return emptyMiddlewareFallback(logger)
 	}
 
-	return newModifierPluginMiddleware(logger, "BACKEND",
+	return newMwPluginMiddleware(logger, "BACKEND",
 		fmt.Sprintf("%s %s -> %s", remote.ParentEndpointMethod, remote.ParentEndpoint, remote.URLPattern), cfg)
 }
 

--- a/proxy/plugin_middleware.go
+++ b/proxy/plugin_middleware.go
@@ -96,7 +96,7 @@ func newMwPluginMiddleware(logger logging.Logger, tag, pattern string, cfg map[s
 			resp, err := next[0](ctx, req)
 
 			if resp == nil {
-				return resp, err
+				return nil, err
 			}
 
 			return responseWrapper{

--- a/proxy/plugin_middleware.go
+++ b/proxy/plugin_middleware.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/luraproject/lura/v2/config"
+	"github.com/luraproject/lura/v2/logging"
+	"github.com/luraproject/lura/v2/proxy/plugin"
+)
+
+// NewMwPluginMiddleware returns an endpoint middleware wrapped (if required) with the plugin middleware.
+// The plugin middleware will try to load all the required plugins from the register and execute them in order.
+func NewMwPluginMiddleware(logger logging.Logger, endpoint *config.EndpointConfig) Middleware {
+	cfg, ok := endpoint.ExtraConfig[plugin.MiddlewareNamespace].(map[string]interface{})
+
+	if !ok {
+		return emptyMiddlewareFallback(logger)
+	}
+
+	return newModifierPluginMiddleware(logger, "ENDPOINT", endpoint.Endpoint, cfg)
+}
+
+// NewBackendMwPluginMiddleware returns a backend middleware wrapped (if required) with the plugin middleware.
+// The plugin middleware will try to load all the required plugins from the register and execute them in order.
+func NewBackendMwPluginMiddleware(logger logging.Logger, remote *config.Backend) Middleware {
+	cfg, ok := remote.ExtraConfig[plugin.MiddlewareNamespace].(map[string]interface{})
+
+	if !ok {
+		return emptyMiddlewareFallback(logger)
+	}
+
+	return newModifierPluginMiddleware(logger, "BACKEND",
+		fmt.Sprintf("%s %s -> %s", remote.ParentEndpointMethod, remote.ParentEndpoint, remote.URLPattern), cfg)
+}
+
+func newMwPluginMiddleware(logger logging.Logger, tag, pattern string, cfg map[string]interface{}) Middleware {
+	plugins, ok := cfg["name"].([]interface{})
+	if !ok {
+		return emptyMiddlewareFallback(logger)
+	}
+
+	var mws []plugin.MiddlewareFactory
+
+	for _, p := range plugins {
+		name, ok := p.(string)
+		if !ok {
+			continue
+		}
+
+		if mf, ok := plugin.GetMiddleware(name); ok {
+			mws = append(mws, mf)
+		}
+	}
+
+	tot := len(mws)
+	if tot == 0 {
+		return emptyMiddlewareFallback(logger)
+	}
+
+	logger.Debug(
+		fmt.Sprintf(
+			"[%s: %s][Middleware Plugins] Adding %d middlewares",
+			tag,
+			pattern,
+			tot,
+		),
+	)
+
+	return func(next ...Proxy) Proxy {
+		if len(next) > 1 {
+			logger.Fatal("too many proxies for this proxy middleware: newMwPluginMiddleware only accepts 1 proxy, got %d tag: %s, pattern: %s",
+				len(next), tag, pattern)
+			return nil
+		}
+
+		// define the end of the pipe of plugin mw
+		p := func(ctx context.Context, r interface{}) (interface{}, error) {
+			tmp, ok := r.(RequestWrapper)
+			if !ok {
+				return nil, fmt.Errorf("unknow type %T", r)
+			}
+
+			req := &Request{}
+
+			req.Method = tmp.Method()
+			req.URL = tmp.URL()
+			req.Query = tmp.Query()
+			req.Path = tmp.Path()
+			req.Body = tmp.Body()
+			req.Params = tmp.Params()
+			req.Headers = tmp.Headers()
+
+			resp, err := next[0](ctx, req)
+
+			if resp == nil {
+				return resp, err
+			}
+
+			return responseWrapper{
+				ctx:        ctx,
+				request:    r,
+				data:       resp.Data,
+				isComplete: resp.IsComplete,
+				metadata: metadataWrapper{
+					headers:    resp.Metadata.Headers,
+					statusCode: resp.Metadata.StatusCode,
+				},
+				io: resp.Io,
+			}, err
+		}
+
+		// stack all the plugin mws
+		for i := tot - 1; i >= 0; i-- {
+			p = mws[i](cfg, p)
+		}
+
+		// return a wrap over the stacked plugins
+		return func(ctx context.Context, r *Request) (*Response, error) {
+			rw := newRequestWrapper(ctx, r)
+			resp, err := p(ctx, rw)
+
+			if resp == nil {
+				return nil, err
+			}
+
+			tmp, ok := resp.(ResponseWrapper)
+			if !ok {
+				return nil, err
+			}
+
+			result := &Response{}
+			result.Data = tmp.Data()
+			result.IsComplete = tmp.IsComplete()
+			result.Io = tmp.Io()
+			result.Metadata = Metadata{}
+			result.Metadata.Headers = tmp.Headers()
+			result.Metadata.StatusCode = tmp.StatusCode()
+			return result, nil
+		}
+	}
+}


### PR DESCRIPTION
As proposed here (https://github.com/luraproject/lura/pull/731#issuecomment-2518272305) this adds support for a new (experimental) type of plugins giving users more freedom when customizing behaviors.

Closes https://github.com/luraproject/lura/issues/730 and #738 

With this implementation, plugins with a var called `MiddlewareRegisterer` that implement the `github.com/luraproject/lura/v2/proxy/plugin.MiddlewareRegisterer` interface
```
type MiddlewareRegisterer interface {
	RegisterMiddlewares(func(
		name string,
		middlewareFactory func(map[string]interface{}, func(context.Context, interface{}) (interface{}, error)) func(context.Context, interface{}) (interface{}, error),
	))
}
```
can be loaded and injected into a chain of plugin middlewares and executed sequentially when processing the request and in the inverse order when processing the response (something resembling the classic [Chain of Responsibility Pattern](https://en.wikipedia.org/wiki/Chain-of-responsibility_pattern)).

This implementation reuses the `RequestWrapper` and `ResponseWrapper` interfaces from the request and response modifier plugins for simplicity.