### PR TITLE
Fix integration tests on macOS

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -38,7 +38,7 @@ import (
 var localhostIP string
 
 func init() {
-	ln, err := net.Listen("tcp", ":8080")
+	ln, err := net.Listen("tcp", "localhost:8080")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
### Fix integration tests by binding the listener to localhost, just like the client

The integration tests were failing because the server listener was configured with `net.Listen("tcp", ":8080")`, without specifying a hostname, which binds to all network interfaces (including IPv6). Meanwhile, the client connection used `net.Dial("tcp", "localhost:8080")`, which resolved to IPv4 (`127.0.0.1`) on my machine.

The discrepancy between the listener accepting both IPv4 and IPv6 and the client specifically using IPv4 may have caused the `X-Forwarded-For` header to be populated with the client’s IP (`127.0.0.1`) instead of being empty, as the tests expected.

Changing the listener to `net.Listen("tcp", "localhost:8080")` ensures the server binds to the same interface as the client, aligning with the test expectations and fixing the failures.

## Evidence

After the modification, the integration tests pass successfully:
```
$ go test -tags integration ./test
ok  	github.com/luraproject/lura/v2/test	3.107s
```

Fixes #753 