### PR TITLE
Add new error type to send response headers

### DIFF
--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -34,7 +34,7 @@ var ErrorResponseWriter = func(c *gin.Context, err error) {
 var EndpointHandler = CustomErrorEndpointHandler(logging.NoOp, server.DefaultToHTTPError)
 
 // CustomErrorEndpointHandler returns a HandlerFactory using the injected ToHTTPError function and logger
-func CustomErrorEndpointHandler(logger logging.Logger, errF server.ToHTTPError) HandlerFactory {
+func CustomErrorEndpointHandler(logger logging.Logger, errF server.ToHTTPError) HandlerFactory { // skipcq: GO-R1005
 	return func(configuration *config.EndpointConfig, prxy proxy.Proxy) gin.HandlerFunc {
 		cacheControlHeaderValue := fmt.Sprintf("public, max-age=%d", int(configuration.CacheTTL.Seconds()))
 		isCacheEnabled := configuration.CacheTTL.Seconds() != 0

--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -97,6 +97,14 @@ func CustomErrorEndpointHandler(logger logging.Logger, errF server.ToHTTPError) 
 					} else {
 						c.Status(errF(err))
 					}
+					if t, ok := err.(headerResponseError); ok {
+						for k, vs := range t.Headers() {
+							for _, v := range vs {
+								c.Writer.Header().Add(k, v)
+							}
+						}
+					}
+
 					if returnErrorMsg {
 						ErrorResponseWriter(c, err)
 					}
@@ -180,6 +188,11 @@ type encodedResponseError interface {
 type responseError interface {
 	error
 	StatusCode() int
+}
+
+type headerResponseError interface {
+	responseError
+	Headers() map[string][]string
 }
 
 type multiError interface {

--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -92,17 +92,17 @@ func CustomErrorEndpointHandler(logger logging.Logger, errF server.ToHTTPError) 
 				}
 
 				if response == nil {
-					if t, ok := err.(responseError); ok {
-						c.Status(t.StatusCode())
-					} else {
-						c.Status(errF(err))
-					}
 					if t, ok := err.(headerResponseError); ok {
 						for k, vs := range t.Headers() {
 							for _, v := range vs {
 								c.Writer.Header().Add(k, v)
 							}
 						}
+					}
+					if t, ok := err.(responseError); ok {
+						c.Status(t.StatusCode())
+					} else {
+						c.Status(errF(err))
 					}
 
 					if returnErrorMsg {


### PR DESCRIPTION
Added a way to write response headers on error

### Usage
If the triggered error implements a `Headers() map[string][]string`, the returned map will be written as response headers. For example, when implementing a quota system, you could return a 429 with a `Retry-After` response header like this:

```
type errProxyQuotaExceeded struct {
	error
	headers map[string][]string
}

func NewErrProxyQuotaExceeded(blockedFor string) error {
	err := errProxyQuotaExceeded{error: errors.New("quota exceeded")}

	err.headers = map[string][]string{
		'Retry-After': {blockedFor},
	}
	return err
}

func (errProxyQuotaExceeded) StatusCode() int {
	return http.StatusTooManyRequests
}

func (e errProxyQuotaExceeded) Headers() map[string][]string {
	return e.headers
}
```