### PR TITLE
Remove deprecated config value usage in mTLS

### DIFF
--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -116,7 +116,7 @@ func RunServerWithLoggerFactory(l logging.Logger) func(context.Context, config.S
 				done <- s.ListenAndServe()
 			}()
 		} else {
-			if len(cfg.TLS.PublicKey) > 0 || len(cfg.TLS.PrivateKey) > 0 {
+			if cfg.TLS.PublicKey != "" || cfg.TLS.PrivateKey != "" {
 				cfg.TLS.Keys = append(cfg.TLS.Keys, config.TLSKeyPair{
 					PublicKey:  cfg.TLS.PublicKey,
 					PrivateKey: cfg.TLS.PrivateKey,

--- a/transport/http/server/server_test.go
+++ b/transport/http/server/server_test.go
@@ -552,7 +552,7 @@ func h2cClient() *http.Client {
 
 // newPort returns random port numbers to avoid port collisions during the tests
 func newPort() int {
-	return 16666 + rand.Intn(40000)
+	return 16666 + rand.Intn(40000) // skipcq: GSC-G404
 }
 
 func TestRunServer_MultipleTLS(t *testing.T) {


### PR DESCRIPTION
When mTLS is enabled, the config parser was still using the deprecated `tls.public_keys`

With these changes, all the keys added to the config are appended to the certificate pool