### PR TITLE
Fix #765 : apply query strings filter before backend request is constructed

### DIFF
--- a/proxy/factory.go
+++ b/proxy/factory.go
@@ -92,11 +92,13 @@ func (pf defaultFactory) newStack(backend *config.Backend) (p Proxy) {
 	p = NewBackendPluginMiddleware(pf.logger, backend)(p)
 	p = NewGraphQLMiddleware(pf.logger, backend)(p)
 	p = NewFilterHeadersMiddleware(pf.logger, backend)(p)
-	p = NewFilterQueryStringsMiddleware(pf.logger, backend)(p)
 	p = NewLoadBalancedMiddlewareWithSubscriberAndLogger(pf.logger, pf.subscriberFactory(backend))(p)
 	if backend.ConcurrentCalls > 1 {
 		p = NewConcurrentMiddlewareWithLogger(pf.logger, backend)(p)
 	}
 	p = NewRequestBuilderMiddlewareWithLogger(pf.logger, backend)(p)
+	// we need to filter the input query strings before the request is constructed
+	// so the query strings are properly added to the URL:
+	p = NewFilterQueryStringsMiddleware(pf.logger, backend)(p)
 	return
 }


### PR DESCRIPTION
Fix #765 

The filtering of the query strings values were made after the backend request URL was already constructed. By applying the filter before, it fixes the issue. 

The issue was reproduced with: https://github.com/luraproject/lura/pull/764#issue-3293643498 

With the current solution, I've checked it works as expected:

## krakend.json

```
{
    "$schema": "https://www.krakend.io/schema/v3.json",
    "version": 3,
    "name": "KrakenD Community API Gateway",
    "port": 8080,
    "host": ["http://localhost:8080"],
    "timeout": "3000ms",
    "debug_endpoint": true,
    "endpoints": [
        {
            "endpoint": "/test",
            "method": "GET",
            "backend": [
                {
                    "encoding": "json",
                    "method": "GET",
                    "host": ["http://localhost:8080"],
                    "input_headers": ["test"],
                    "input_query_strings": ["test"],
                    "url_pattern": "/__debug/?foo=bar"
                }
            ],
            "input_headers": ["test", "test2"],
            "input_query_strings": ["test", "test2"]
        }
    ],
    "sequential_start": false
}
```

## Tests:

```
$ curl 'localhost:8080/test?k=p&test=a&test2=b&pp=j'
```

```
2025/08/18 19:06:02 KRAKEND DEBUG: [ENDPOINT: /__debug/*] Body:
 2025/08/18 - 19:06:02.374 [AccessLog] | 200 | 2.301ms |       127.0.0.1 | GET      /__debug/?foo=bar&test=a
 2025/08/18 - 19:06:02.376 [AccessLog] | 200 | 5.581ms |             ::1 | GET      /test?k=p&test=a&test2=b&pp=j
```

and without backend filtering:
```
$ curl 'localhost:8080/test?k=p'
```

```
2025/08/18 19:06:25 KRAKEND DEBUG: [ENDPOINT: /__debug/*] Body:
 2025/08/18 - 19:06:25.163 [AccessLog] | 200 | 0.297ms |       127.0.0.1 | GET      /__debug/?foo=bar
 2025/08/18 - 19:06:25.164 [AccessLog] | 200 | 1.312ms |             ::1 | GET      /test?k=p
```

