### PR TITLE
Revert "Fix integration tests on macOS"

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -38,7 +38,7 @@ import (
 var localhostIP string
 
 func init() {
-	ln, err := net.Listen("tcp", "localhost:8080")
+	ln, err := net.Listen("tcp", ":8080")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Reverts luraproject/lura#754

Depending on the host where this is being executed, the result is different. I'll revert those changes because the solution seems flaky depending on where it is executed.