### PR TITLE
Plugin extra components registerers

### DIFF
--- a/proxy/plugin/modifier.go
+++ b/proxy/plugin/modifier.go
@@ -169,9 +169,13 @@ func open(ctx context.Context, pluginName string, rmf RegisterModifierFunc, logg
 		lr.RegisterContext(ctx)
 	}
 
+	RegisterExtraComponents(r)
+
 	registerer.RegisterModifiers(rmf)
 	return
 }
+
+var RegisterExtraComponents = func(interface{}) {}
 
 // Plugin is the interface of the loaded plugins
 type Plugin interface {

--- a/transport/http/client/plugin/plugin.go
+++ b/transport/http/client/plugin/plugin.go
@@ -101,9 +101,13 @@ func open(pluginName string, rcf RegisterClientFunc, logger logging.Logger) (err
 		}
 	}
 
+	RegisterExtraComponents(r)
+
 	registerer.RegisterClients(rcf)
 	return
 }
+
+var RegisterExtraComponents = func(interface{}) {}
 
 // Plugin is the interface of the loaded plugins
 type Plugin interface {

--- a/transport/http/server/plugin/plugin.go
+++ b/transport/http/server/plugin/plugin.go
@@ -101,9 +101,13 @@ func open(pluginName string, rcf RegisterHandlerFunc, logger logging.Logger) (er
 		}
 	}
 
+	RegisterExtraComponents(r)
+
 	registerer.RegisterHandlers(rcf)
 	return
 }
+
+var RegisterExtraComponents = func(interface{}) {}
 
 // Plugin is the interface of the loaded plugins
 type Plugin interface {


### PR DESCRIPTION
Adding an exported `RegisterExtraComponents` function in all plugin types. 

This function receives the plugin symbol itself, so it can be customized to register more components besides the logger or the context, for example, a persistence layer.