### PR TITLE
Bugfix for Issue 782

### DIFF
--- a/async/asyncagent.go
+++ b/async/asyncagent.go
@@ -82,7 +82,7 @@ func (a AgentStarter) Start(
 		}
 
 		if agent.Connection.MaxRetries <= 0 {
-			agent.Connection.MaxRetries = math.MaxInt64
+			agent.Connection.MaxRetries = math.MaxInt
 		}
 
 		opts := Options{


### PR DESCRIPTION
Fixes Issue 782 by changing default value of MaxInt64 to MaxInt.

The type of `agent.Connection.MaxRetries` was already `int`.
This now matches the type of the configuration allowing for support of Armv7.

When running `GOOS=linux GOARCH=arm GOARM=7 make build`, no build issues arise.