### PR TITLE
fix interpolation behavior in various parts of the GraphQL configuration

### DIFF
--- a/transport/http/client/graphql/graphql.go
+++ b/transport/http/client/graphql/graphql.go
@@ -12,12 +12,16 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/luraproject/lura/v2/config"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
+
+// urlKeysPattern matches URL path parameters in the form {paramName}.
+var urlKeysPattern = regexp.MustCompile(`\{([\w\-.:/]+)\}`)
 
 // Namespace is the key for the backend's extra config
 const Namespace = "github.com/devopsfaith/krakend/transport/http/client/graphql"
@@ -100,8 +104,8 @@ func New(opt Options) *Extractor {
 		if !ok {
 			continue
 		}
-		if val[0] == '{' && val[len(val)-1] == '}' {
-			replacements = append(replacements, [2]string{k, title.String(val[1:2]) + val[2:len(val)-1]})
+		if urlKeysPattern.MatchString(val) {
+			replacements = append(replacements, [2]string{k, val})
 		}
 	}
 
@@ -129,7 +133,14 @@ func New(opt Options) *Extractor {
 			val.Variables[k] = v
 		}
 		for _, vs := range replacements {
-			val.Variables[vs[0]] = params[vs[1]]
+			val.Variables[vs[0]] = urlKeysPattern.ReplaceAllStringFunc(vs[1], func(match string) string {
+				param := match[1 : len(match)-1]
+				key := title.String(param[:1]) + param[1:]
+				if v, ok := params[key]; ok {
+					return v
+				}
+				return match
+			})
 		}
 		return &val, nil
 	}

--- a/transport/http/client/graphql/graphql.go
+++ b/transport/http/client/graphql/graphql.go
@@ -96,7 +96,10 @@ func GetOptions(cfg config.ExtraConfig) (*Options, error) {
 
 // New resturns a new Extractor, ready to be use on a middleware
 func New(opt Options) *Extractor {
-	var replacements [][2]string
+	// templates holds [varKey, templateString] pairs where {param} has been
+	// pre-converted to {{.Param}} at setup time, mirroring the approach used
+	// in config.go for url_pattern interpolation.
+	var templates [][2]string
 
 	title := cases.Title(language.Und)
 	for k, v := range opt.Variables {
@@ -104,12 +107,17 @@ func New(opt Options) *Extractor {
 		if !ok {
 			continue
 		}
-		if urlKeysPattern.MatchString(val) {
-			replacements = append(replacements, [2]string{k, val})
+		// Convert all {param} occurrences to {{.Param}} once at setup time.
+		tmpl := urlKeysPattern.ReplaceAllStringFunc(val, func(match string) string {
+			param := match[1 : len(match)-1]
+			return "{{." + title.String(param[:1]) + param[1:] + "}}"
+		})
+		if tmpl != val {
+			templates = append(templates, [2]string{k, tmpl})
 		}
 	}
 
-	if len(replacements) == 0 {
+	if len(templates) == 0 {
 		b, _ := json.Marshal(opt.GraphQLRequest)
 
 		return &Extractor{
@@ -132,15 +140,13 @@ func New(opt Options) *Extractor {
 		for k, v := range opt.Variables {
 			val.Variables[k] = v
 		}
-		for _, vs := range replacements {
-			val.Variables[vs[0]] = urlKeysPattern.ReplaceAllStringFunc(vs[1], func(match string) string {
-				param := match[1 : len(match)-1]
-				key := title.String(param[:1]) + param[1:]
-				if v, ok := params[key]; ok {
-					return v
-				}
-				return match
-			})
+		// Per-request: plain strings.ReplaceAll, no regex — same as proxy.GeneratePath.
+		for _, tmpl := range templates {
+			buff := tmpl[1]
+			for k, v := range params {
+				buff = strings.ReplaceAll(buff, "{{."+k+"}}", v)
+			}
+			val.Variables[tmpl[0]] = buff
 		}
 		return &val, nil
 	}

--- a/transport/http/client/graphql/graphql_benchmark_test.go
+++ b/transport/http/client/graphql/graphql_benchmark_test.go
@@ -3,70 +3,58 @@
 package graphql
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/luraproject/lura/v2/config"
 )
 
-// legacyInterpolate reproduces the original per-request substitution: direct map lookup.
-func legacyInterpolate(replacements [][2]string, variables map[string]interface{}, params map[string]string) {
-	for _, vs := range replacements {
-		variables[vs[0]] = params[vs[1]]
-	}
-}
-
-// fixedInterpolate is the new per-request substitution: strings.ReplaceAll loop (mirrors proxy.GeneratePath).
-func fixedInterpolate(templates [][2]string, variables map[string]interface{}, params map[string]string) {
-	for _, tmpl := range templates {
-		buff := tmpl[1]
-		for k, v := range params {
-			buff = strings.ReplaceAll(buff, "{{."+k+"}}", v)
-		}
-		variables[tmpl[0]] = buff
-	}
-}
-
-var (
-	// legacy: replacements built as [varKey, capitalizedParamKey]
-	legacyReplacements = [][2]string{
-		{"single", "Owner"},
-	}
-
-	// fixed: templates built as [varKey, "{{.Owner}}/{{.Repo}} ..."]
-	fixedTemplates = [][2]string{
-		{"single", "{{.Owner}}"},
-		{"compound", "repo:{{.Owner}}/{{.Repo}} category:Announcements"},
-	}
-
-	benchVariables = map[string]interface{}{
-		"single":   "{owner}",
-		"compound": "repo:{owner}/{repo} category:Announcements",
-		"static":   "no-params-here",
-	}
-
-	benchParams = map[string]string{
+func BenchmarkExtractor_BodyFromParams(b *testing.B) {
+	params := map[string]string{
 		"Owner": "krakend",
 		"Repo":  "lura",
 	}
-)
 
-func BenchmarkInterpolation_legacy(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		vars := map[string]interface{}{}
-		for k, v := range benchVariables {
-			vars[k] = v
-		}
-		legacyInterpolate(legacyReplacements, vars, benchParams)
-	}
-}
+	for _, tc := range []struct {
+		name      string
+		variables map[string]interface{}
+	}{
+		{
+			name:      "no_params",
+			variables: map[string]interface{}{"static": "no-params-here"},
+		},
+		{
+			name:      "single_param",
+			variables: map[string]interface{}{"owner": "{owner}"},
+		},
+		{
+			name: "compound_params",
+			variables: map[string]interface{}{
+				"query": "repo:{owner}/{repo} category:Announcements",
+			},
+		},
+		{
+			name: "mixed",
+			variables: map[string]interface{}{
+				"single":   "{owner}",
+				"compound": "repo:{owner}/{repo} category:Announcements",
+				"static":   "no-params-here",
+			},
+		},
+	} {
+		cfg, _ := GetOptions(config.ExtraConfig{
+			Namespace: map[string]interface{}{
+				"type":      OperationQuery,
+				"query":     "{ search(query: $query) { nodes { id } } }",
+				"variables": tc.variables,
+			},
+		})
+		extractor := New(*cfg)
 
-func BenchmarkInterpolation_fixed(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		vars := map[string]interface{}{}
-		for k, v := range benchVariables {
-			vars[k] = v
-		}
-		fixedInterpolate(fixedTemplates, vars, benchParams)
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				extractor.BodyFromParams(params)
+			}
+		})
 	}
 }

--- a/transport/http/client/graphql/graphql_benchmark_test.go
+++ b/transport/http/client/graphql/graphql_benchmark_test.go
@@ -3,90 +3,70 @@
 package graphql
 
 import (
-	"encoding/json"
+	"strings"
 	"testing"
-
-	"github.com/luraproject/lura/v2/config"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
-// legacyNew reproduces the original New() behavior before the fix, for comparison.
-func legacyNew(opt Options) *Extractor {
-	var replacements [][2]string
-
-	title := cases.Title(language.Und)
-	for k, v := range opt.Variables {
-		val, ok := v.(string)
-		if !ok {
-			continue
-		}
-		if len(val) > 0 && val[0] == '{' && val[len(val)-1] == '}' {
-			replacements = append(replacements, [2]string{k, title.String(val[1:2]) + val[2:len(val)-1]})
-		}
-	}
-
-	paramExtractor := func(params map[string]string) (*GraphQLRequest, error) {
-		val := GraphQLRequest{
-			Query:         opt.Query,
-			OperationName: opt.OperationName,
-			Variables:     map[string]interface{}{},
-		}
-		for k, v := range opt.Variables {
-			val.Variables[k] = v
-		}
-		for _, vs := range replacements {
-			val.Variables[vs[0]] = params[vs[1]]
-		}
-		return &val, nil
-	}
-
-	return &Extractor{
-		cfg:            opt,
-		paramExtractor: paramExtractor,
-		newBody: func(params map[string]string) ([]byte, error) {
-			val, err := paramExtractor(params)
-			if err != nil {
-				return []byte{}, err
-			}
-			return json.Marshal(val)
-		},
+// legacyInterpolate reproduces the original per-request substitution: direct map lookup.
+func legacyInterpolate(replacements [][2]string, variables map[string]interface{}, params map[string]string) {
+	for _, vs := range replacements {
+		variables[vs[0]] = params[vs[1]]
 	}
 }
 
-var benchCfg = config.ExtraConfig{
-	Namespace: map[string]interface{}{
-		"type":  OperationQuery,
-		"query": "{ search(query: $query) { nodes { id } } }",
-		"variables": map[string]interface{}{
-			"single":   "{owner}",
-			"compound": "repo:{owner}/{repo} category:Announcements",
-			"static":   "no-params-here",
-		},
-	},
+// fixedInterpolate is the new per-request substitution: strings.ReplaceAll loop (mirrors proxy.GeneratePath).
+func fixedInterpolate(templates [][2]string, variables map[string]interface{}, params map[string]string) {
+	for _, tmpl := range templates {
+		buff := tmpl[1]
+		for k, v := range params {
+			buff = strings.ReplaceAll(buff, "{{."+k+"}}", v)
+		}
+		variables[tmpl[0]] = buff
+	}
 }
 
-var benchParams = map[string]string{
-	"Owner": "krakend",
-	"Repo":  "lura",
-}
+var (
+	// legacy: replacements built as [varKey, capitalizedParamKey]
+	legacyReplacements = [][2]string{
+		{"single", "Owner"},
+	}
 
-func BenchmarkBodyFromParams_legacy(b *testing.B) {
-	cfg, _ := GetOptions(benchCfg)
-	extractor := legacyNew(*cfg)
+	// fixed: templates built as [varKey, "{{.Owner}}/{{.Repo}} ..."]
+	fixedTemplates = [][2]string{
+		{"single", "{{.Owner}}"},
+		{"compound", "repo:{{.Owner}}/{{.Repo}} category:Announcements"},
+	}
+
+	benchVariables = map[string]interface{}{
+		"single":   "{owner}",
+		"compound": "repo:{owner}/{repo} category:Announcements",
+		"static":   "no-params-here",
+	}
+
+	benchParams = map[string]string{
+		"Owner": "krakend",
+		"Repo":  "lura",
+	}
+)
+
+func BenchmarkInterpolation_legacy(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		extractor.BodyFromParams(benchParams)
+		vars := map[string]interface{}{}
+		for k, v := range benchVariables {
+			vars[k] = v
+		}
+		legacyInterpolate(legacyReplacements, vars, benchParams)
 	}
 }
 
-func BenchmarkBodyFromParams_fixed(b *testing.B) {
-	cfg, _ := GetOptions(benchCfg)
-	extractor := New(*cfg)
+func BenchmarkInterpolation_fixed(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		extractor.BodyFromParams(benchParams)
+		vars := map[string]interface{}{}
+		for k, v := range benchVariables {
+			vars[k] = v
+		}
+		fixedInterpolate(fixedTemplates, vars, benchParams)
 	}
 }

--- a/transport/http/client/graphql/graphql_benchmark_test.go
+++ b/transport/http/client/graphql/graphql_benchmark_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package graphql
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/luraproject/lura/v2/config"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// legacyNew reproduces the original New() behavior before the fix, for comparison.
+func legacyNew(opt Options) *Extractor {
+	var replacements [][2]string
+
+	title := cases.Title(language.Und)
+	for k, v := range opt.Variables {
+		val, ok := v.(string)
+		if !ok {
+			continue
+		}
+		if len(val) > 0 && val[0] == '{' && val[len(val)-1] == '}' {
+			replacements = append(replacements, [2]string{k, title.String(val[1:2]) + val[2:len(val)-1]})
+		}
+	}
+
+	paramExtractor := func(params map[string]string) (*GraphQLRequest, error) {
+		val := GraphQLRequest{
+			Query:         opt.Query,
+			OperationName: opt.OperationName,
+			Variables:     map[string]interface{}{},
+		}
+		for k, v := range opt.Variables {
+			val.Variables[k] = v
+		}
+		for _, vs := range replacements {
+			val.Variables[vs[0]] = params[vs[1]]
+		}
+		return &val, nil
+	}
+
+	return &Extractor{
+		cfg:            opt,
+		paramExtractor: paramExtractor,
+		newBody: func(params map[string]string) ([]byte, error) {
+			val, err := paramExtractor(params)
+			if err != nil {
+				return []byte{}, err
+			}
+			return json.Marshal(val)
+		},
+	}
+}
+
+var benchCfg = config.ExtraConfig{
+	Namespace: map[string]interface{}{
+		"type":  OperationQuery,
+		"query": "{ search(query: $query) { nodes { id } } }",
+		"variables": map[string]interface{}{
+			"single":   "{owner}",
+			"compound": "repo:{owner}/{repo} category:Announcements",
+			"static":   "no-params-here",
+		},
+	},
+}
+
+var benchParams = map[string]string{
+	"Owner": "krakend",
+	"Repo":  "lura",
+}
+
+func BenchmarkBodyFromParams_legacy(b *testing.B) {
+	cfg, _ := GetOptions(benchCfg)
+	extractor := legacyNew(*cfg)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		extractor.BodyFromParams(benchParams)
+	}
+}
+
+func BenchmarkBodyFromParams_fixed(b *testing.B) {
+	cfg, _ := GetOptions(benchCfg)
+	extractor := New(*cfg)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		extractor.BodyFromParams(benchParams)
+	}
+}

--- a/transport/http/client/graphql/graphql_test.go
+++ b/transport/http/client/graphql/graphql_test.go
@@ -179,6 +179,36 @@ func ExampleExtractor_fromFile() {
 
 }
 
+func ExampleExtractor_multipleParamsInVariable() {
+	cfg, err := GetOptions(config.ExtraConfig{
+		Namespace: map[string]interface{}{
+			"type":  OperationQuery,
+			"query": "{\n  search(query: $query) {\n    nodes { id }\n  }\n}\n",
+			"variables": map[string]interface{}{
+				"query": "repo:{owner}/{repo} category:Announcements",
+			},
+		},
+	})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	extractor := New(*cfg)
+
+	body, err := extractor.BodyFromParams(map[string]string{
+		"Owner": "krakend",
+		"Repo":  "lura",
+	})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(string(body))
+
+	// output:
+	// {"query":"{\n  search(query: $query) {\n    nodes { id }\n  }\n}\n","variables":{"query":"repo:krakend/lura category:Announcements"}}
+}
+
 func ExampleExtractor_noReplacement() {
 	cfg, err := GetOptions(config.ExtraConfig{
 		Namespace: map[string]interface{}{


### PR DESCRIPTION
What does this PR do?

Fixes inconsistent interpolation behavior in various parts of the configuration bug (#660)

> When using endpoint parameters in backend/graphql variables, it is not possible to have a string containing multiple parameters as in url_pattern. 

Also test added.