### PR TITLE
Update lock-threads gh action version to fix the token validation pro…

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -16,7 +16,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v3
+      - uses: dessant/lock-threads@v6
         with:
           pr-inactive-days: '90'
           issue-inactive-days: '90'


### PR DESCRIPTION
…blem arised by the new tokens provided by github (which are now larger than before).