### PR TITLE
feat(client/plugin): stream HTTP client plugin responses

### DIFF
--- a/proxy/http.go
+++ b/proxy/http.go
@@ -111,6 +111,12 @@ func NewHTTPProxyDetailed(cfg *config.Backend, re client.HTTPRequestExecutor, ch
 
 		select {
 		case <-ctx.Done():
+			// re may return a streaming body backed by a live goroutine (e.g. client
+			// plugins). Close it so the producer unwinds instead of leaking on this
+			// early return, where the response parser that would wrap it never runs.
+			if resp != nil && resp.Body != nil {
+				resp.Body.Close()
+			}
 			return nil, ctx.Err()
 		default:
 		}
@@ -118,6 +124,12 @@ func NewHTTPProxyDetailed(cfg *config.Backend, re client.HTTPRequestExecutor, ch
 			return nil, err
 		}
 
+		// ch may reject the response and return (nil, err) (e.g. the default status handler
+		// on a bad status code), dropping the response it was handed. Keep a handle to that
+		// body so the fall-through below can close it instead of leaking a streaming producer
+		// goroutine; the responseError branch forwards the error and leaves the body to its
+		// own handler (newHTTPResponseError already drained and replaced it).
+		respBeforeStatusHandler := resp
 		resp, err = ch(ctx, resp)
 		if err != nil {
 			if t, ok := err.(responseError); ok {
@@ -127,6 +139,9 @@ func NewHTTPProxyDetailed(cfg *config.Backend, re client.HTTPRequestExecutor, ch
 					},
 					Metadata: Metadata{StatusCode: t.StatusCode()},
 				}, nil
+			}
+			if respBeforeStatusHandler != nil && respBeforeStatusHandler.Body != nil {
+				respBeforeStatusHandler.Body.Close()
 			}
 			return nil, err
 		}

--- a/proxy/http_test.go
+++ b/proxy/http_test.go
@@ -134,6 +134,79 @@ func TestNewHTTPProxy_cancel(t *testing.T) {
 	}
 }
 
+// recordingBody is a response body that counts how many times it is closed, so a test can
+// assert the proxy releases a streaming producer rather than leaking it.
+type recordingBody struct {
+	io.Reader
+	closes int32
+}
+
+func (b *recordingBody) Close() error {
+	atomic.AddInt32(&b.closes, 1)
+	return nil
+}
+
+func TestNewHTTPProxyDetailed_cancelClosesBody(t *testing.T) {
+	body := &recordingBody{Reader: strings.NewReader("streaming")}
+	re := func(_ context.Context, _ *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled: the proxy must drop and close the response body
+
+	prxy := NewHTTPProxyDetailed(&config.Backend{}, re, client.NoOpHTTPStatusHandler, NoOpHTTPResponseParser)
+	resp, err := prxy(ctx, &Request{
+		Method: "GET",
+		Path:   "/",
+		URL:    &url.URL{Scheme: "http", Host: "example.com"},
+		Body:   newDummyReadCloser(""),
+	})
+
+	if err == nil {
+		t.Error("expected the cancelled-context error, got nil")
+		return
+	}
+	if resp != nil {
+		t.Errorf("expected no response on cancellation, got %v", resp)
+		return
+	}
+	if n := atomic.LoadInt32(&body.closes); n != 1 {
+		t.Errorf("expected the dropped streaming body closed exactly once, got %d closes", n)
+	}
+}
+
+func TestNewHTTPProxyDetailed_badStatusClosesStreamingBody(t *testing.T) {
+	body := &recordingBody{Reader: strings.NewReader("boom")}
+	re := func(_ context.Context, _ *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusInternalServerError, Body: body}, nil
+	}
+
+	// No return_error_details/return_error_code -> the default status handler, which returns
+	// (nil, *ErrInvalidStatus); that error is not a responseError, so the proxy must still
+	// close the streaming body it was handed.
+	backend := &config.Backend{}
+	prxy := NewHTTPProxyDetailed(backend, re, client.GetHTTPStatusHandler(backend), NoOpHTTPResponseParser)
+	resp, err := prxy(context.Background(), &Request{
+		Method: "GET",
+		Path:   "/",
+		URL:    &url.URL{Scheme: "http", Host: "example.com"},
+		Body:   newDummyReadCloser(""),
+	})
+
+	if err == nil || !strings.HasPrefix(err.Error(), "invalid status code") {
+		t.Errorf("expected an invalid status code error, got %v", err)
+		return
+	}
+	if resp != nil {
+		t.Errorf("expected no response on a rejected status, got %v", resp)
+		return
+	}
+	if n := atomic.LoadInt32(&body.closes); n != 1 {
+		t.Errorf("expected the rejected streaming body closed exactly once, got %d closes", n)
+	}
+}
+
 func TestNewHTTPProxy_badResponseBody(t *testing.T) {
 	expectedMethod := "GET"
 	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/transport/http/client/plugin/executor.go
+++ b/transport/http/client/plugin/executor.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 
 	"github.com/luraproject/lura/v2/config"
 	"github.com/luraproject/lura/v2/logging"
@@ -72,9 +71,7 @@ func HTTPRequestExecutorWithContext(
 
 		logger.Debug(logPrefix, "Injecting plugin", name)
 		return func(ctx context.Context, req *http.Request) (*http.Response, error) {
-			w := httptest.NewRecorder()
-			handler.ServeHTTP(w, req.WithContext(ctx))
-			return w.Result(), nil
+			return executePluginHandler(ctx, logger, logPrefix, handler, req), nil
 		}
 	}
 }

--- a/transport/http/client/plugin/streaming.go
+++ b/transport/http/client/plugin/streaming.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/luraproject/lura/v2/logging"
+)
+
+// executePluginHandler runs an HTTP client plugin handler and exposes its output as an
+// *http.Response whose Body streams as the handler writes it.
+//
+// The handler runs in a goroutine writing into an io.Pipe; the call returns as soon as the
+// status line and headers are committed (the first WriteHeader/Write/Flush, or the handler
+// returning), with the pipe's read end as the body.
+//
+// The pipe is unbuffered, so a handler that keeps writing parks in Write until the body is
+// read or closed; it unwinds once ctx is cancelled (a watcher then closes the read end) or
+// the caller reads or closes the body. A caller that drops the response without reading it
+// must therefore cancel ctx or close the body to release the goroutine.
+func executePluginHandler(ctx context.Context, logger logging.Logger, logPrefix string, handler http.Handler, req *http.Request) *http.Response {
+	pr, pw := io.Pipe()
+	w := newStreamingResponseWriter(pw)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer func() {
+			if rec := recover(); rec != nil {
+				logger.Error(logPrefix, "client plugin handler panicked:", rec)
+				pw.CloseWithError(fmt.Errorf("client plugin handler panicked: %v", rec))
+				// Surface the failure as a 5xx if the handler had not committed a
+				// status yet; commit is a no-op once the headers are sent.
+				w.commit(http.StatusBadGateway)
+			} else {
+				pw.Close()
+				// A handler that returned without writing still commits an implicit
+				// 200 so the caller never waits on headers that never come.
+				w.commit(http.StatusOK)
+			}
+		}()
+		handler.ServeHTTP(w, req.WithContext(ctx))
+	}()
+
+	// Closing the read end unblocks a handler parked on Write with ErrClosedPipe, so the
+	// goroutine unwinds on cancellation regardless of whether a consumer reads the body.
+	// Gated on done so the watcher never outlives the handler.
+	go func() {
+		select {
+		case <-ctx.Done():
+			pr.CloseWithError(ctx.Err())
+		case <-done:
+		}
+	}()
+
+	// Block only until the status line and headers are known; the body keeps streaming
+	// through the pipe after we return.
+	select {
+	case <-w.committed:
+		return newStreamingResponse(w.statusCode, w.committedHeader, pr, req)
+	case <-ctx.Done():
+		// The context was cancelled before the handler committed any headers; the watcher
+		// has closed the body so reads yield ctx.Err(). Synthesise a response instead of
+		// blocking on a handler that may never write.
+		return newStreamingResponse(http.StatusGatewayTimeout, make(http.Header), pr, req)
+	}
+}
+
+// newStreamingResponse builds the *http.Response returned by executePluginHandler. The body
+// length is unknown up front (the handler streams into a pipe), hence ContentLength -1.
+func newStreamingResponse(statusCode int, header http.Header, body io.ReadCloser, req *http.Request) *http.Response {
+	return &http.Response{
+		StatusCode:    statusCode,
+		Status:        fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        header,
+		Body:          body,
+		ContentLength: -1,
+		Request:       req,
+	}
+}
+
+// streamingResponseWriter is an http.ResponseWriter that pipes everything written to it
+// into an *http.Response body. It records the status code and a snapshot of the headers
+// the first time the handler commits them (WriteHeader, or the first Write).
+type streamingResponseWriter struct {
+	header          http.Header
+	pw              *io.PipeWriter
+	statusCode      int
+	committedHeader http.Header
+	once            sync.Once
+	committed       chan struct{}
+}
+
+func newStreamingResponseWriter(pw *io.PipeWriter) *streamingResponseWriter {
+	return &streamingResponseWriter{
+		header:     make(http.Header),
+		pw:         pw,
+		statusCode: http.StatusOK,
+		committed:  make(chan struct{}),
+	}
+}
+
+func (w *streamingResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *streamingResponseWriter) WriteHeader(statusCode int) {
+	w.commit(statusCode)
+}
+
+func (w *streamingResponseWriter) Write(p []byte) (int, error) {
+	// An implicit 200 OK is committed on the first write, like net/http.
+	w.commit(http.StatusOK)
+	return w.pw.Write(p)
+}
+
+// Flush commits the status line and headers if the handler has not done so yet, mirroring
+// net/http's implicit WriteHeader(200) on Flush, so a handler that flushes before its first
+// write still unblocks the caller. The pipe is unbuffered, so body bytes are already
+// delivered as they are written.
+func (w *streamingResponseWriter) Flush() {
+	w.commit(http.StatusOK)
+}
+
+// commit freezes the status code and headers exactly once and signals the waiting caller.
+func (w *streamingResponseWriter) commit(statusCode int) {
+	w.once.Do(func() {
+		w.statusCode = statusCode
+		w.committedHeader = w.header.Clone()
+		close(w.committed)
+	})
+}
+
+var _ http.ResponseWriter = (*streamingResponseWriter)(nil)
+var _ http.Flusher = (*streamingResponseWriter)(nil)

--- a/transport/http/client/plugin/streaming_test.go
+++ b/transport/http/client/plugin/streaming_test.go
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luraproject/lura/v2/logging"
+)
+
+func TestExecutePluginHandler_StreamsIncrementally(t *testing.T) {
+	release := make(chan struct{})
+	handlerDone := make(chan struct{})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		defer close(handlerDone)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if _, err := io.WriteString(w, "data: first\n\n"); err != nil {
+			t.Errorf("write first: %v", err)
+			return
+		}
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Block: the handler has NOT returned. If the executor buffered the response, the
+		// caller below could not read "first" yet.
+		<-release
+		if _, err := io.WriteString(w, "data: second\n\n"); err != nil {
+			t.Errorf("write second: %v", err)
+		}
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/sse", http.NoBody)
+	resp := executePluginHandler(context.Background(), logging.NoOp, "", handler, req)
+
+	if resp.StatusCode != http.StatusOK {
+		close(release)
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+		return
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		close(release)
+		t.Errorf("expected text/event-stream, got %q", ct)
+		return
+	}
+
+	// Read the first event while the handler is still blocked on <-release.
+	first := make([]byte, len("data: first\n\n"))
+	if _, err := io.ReadFull(resp.Body, first); err != nil {
+		close(release)
+		t.Errorf("reading first event: %v", err)
+		return
+	}
+	if string(first) != "data: first\n\n" {
+		close(release)
+		t.Errorf("expected first event, got %q", string(first))
+		return
+	}
+
+	select {
+	case <-handlerDone:
+		close(release)
+		t.Error("handler returned before we read the first event, response was buffered")
+		return
+	default:
+	}
+
+	// Let the handler finish and emit the second event.
+	close(release)
+	second := make([]byte, len("data: second\n\n"))
+	if _, err := io.ReadFull(resp.Body, second); err != nil {
+		t.Errorf("reading second event: %v", err)
+		return
+	}
+	if string(second) != "data: second\n\n" {
+		t.Errorf("expected second event, got %q", string(second))
+		return
+	}
+
+	if rest, err := io.ReadAll(resp.Body); err != nil || len(rest) != 0 {
+		t.Errorf("expected clean EOF after stream, got %q err=%v", string(rest), err)
+		return
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("close body: %v", err)
+	}
+}
+
+func TestExecutePluginHandler_NoBody(t *testing.T) {
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/", http.NoBody)
+	resp := executePluginHandler(context.Background(), logging.NoOp, "", handler, req)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected implicit 200, got %d", resp.StatusCode)
+		return
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("read body: %v", err)
+		return
+	}
+	if len(body) != 0 {
+		t.Errorf("expected empty body, got %q", string(body))
+		return
+	}
+	_ = resp.Body.Close()
+}
+
+func TestExecutePluginHandler_NonOKStatus(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Err", "1")
+		w.WriteHeader(http.StatusInternalServerError)
+		if _, err := io.WriteString(w, "boom"); err != nil {
+			t.Errorf("write body: %v", err)
+		}
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/", http.NoBody)
+	resp := executePluginHandler(context.Background(), logging.NoOp, "", handler, req)
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", resp.StatusCode)
+		return
+	}
+	if resp.Status != "500 Internal Server Error" {
+		t.Errorf("expected status line %q, got %q", "500 Internal Server Error", resp.Status)
+		return
+	}
+	if got := resp.Header.Get("X-Err"); got != "1" {
+		t.Errorf("expected X-Err header, got %q", got)
+		return
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("read body: %v", err)
+		return
+	}
+	if string(body) != "boom" {
+		t.Errorf("expected body %q, got %q", "boom", string(body))
+		return
+	}
+	_ = resp.Body.Close()
+}
+
+func TestExecutePluginHandler_HeaderSnapshotFrozenAtCommit(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Before", "yes")
+		w.WriteHeader(http.StatusCreated)
+		// Everything below happens after the first commit and must be ignored.
+		w.Header().Set("X-After", "nope")
+		w.WriteHeader(http.StatusInternalServerError)
+		if _, err := io.WriteString(w, "body"); err != nil {
+			t.Errorf("write body: %v", err)
+		}
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/", http.NoBody)
+	resp := executePluginHandler(context.Background(), logging.NoOp, "", handler, req)
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("expected first committed status 201, got %d", resp.StatusCode)
+		return
+	}
+	if got := resp.Header.Get("X-Before"); got != "yes" {
+		t.Errorf("expected X-Before in the frozen snapshot, got %q", got)
+		return
+	}
+	if got := resp.Header.Get("X-After"); got != "" {
+		t.Errorf("expected X-After absent from the frozen snapshot, got %q", got)
+		return
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Errorf("read body: %v", err)
+		return
+	}
+	_ = resp.Body.Close()
+}
+
+func TestExecutePluginHandler_FlushCommitsHeaders(t *testing.T) {
+	release := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Stream", "ready")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush() // commit status+headers without WriteHeader/Write
+		}
+		<-release // block before writing any body
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/", http.NoBody)
+
+	done := make(chan *http.Response, 1)
+	go func() { done <- executePluginHandler(context.Background(), logging.NoOp, "", handler, req) }()
+
+	select {
+	case resp := <-done:
+		if resp.StatusCode != http.StatusOK {
+			close(release)
+			t.Errorf("expected implicit 200 after flush, got %d", resp.StatusCode)
+			return
+		}
+		if got := resp.Header.Get("X-Stream"); got != "ready" {
+			close(release)
+			t.Errorf("expected header committed by Flush, got %q", got)
+			return
+		}
+		close(release)
+		_ = resp.Body.Close()
+	case <-time.After(2 * time.Second):
+		close(release)
+		t.Error("executePluginHandler did not return after Flush; Flush must commit headers")
+	}
+}
+
+func TestExecutePluginHandler_ContextCancellationUnblocksWriter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	handlerReturned := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		defer close(handlerReturned)
+		w.WriteHeader(http.StatusOK)
+		if _, err := io.WriteString(w, "chunk"); err != nil {
+			t.Errorf("write first chunk: %v", err)
+			return
+		}
+		// This write blocks: nobody reads it. It must fail once the context is cancelled
+		// and the watcher closes the pipe, rather than block forever.
+		if _, err := io.WriteString(w, "blocked"); err == nil {
+			t.Errorf("expected write to fail after context cancellation")
+		}
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/", http.NoBody)
+	resp := executePluginHandler(ctx, logging.NoOp, "", handler, req)
+
+	first := make([]byte, len("chunk"))
+	if _, err := io.ReadFull(resp.Body, first); err != nil {
+		t.Errorf("reading first chunk: %v", err)
+		return
+	}
+
+	cancel()
+
+	select {
+	case <-handlerReturned:
+	case <-time.After(2 * time.Second):
+		t.Error("handler goroutine did not unblock after context cancellation")
+	}
+	_ = resp.Body.Close()
+}
+
+func TestExecutePluginHandler_ContextCancelledBeforeCommit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		close(started)
+		// Block without ever committing a status, so only ctx cancellation can return.
+		<-unblock
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/", http.NoBody)
+
+	done := make(chan *http.Response, 1)
+	go func() { done <- executePluginHandler(ctx, logging.NoOp, "", handler, req) }()
+
+	<-started
+	cancel() // cancel before the handler commits any status
+
+	select {
+	case resp := <-done:
+		if resp.StatusCode != http.StatusGatewayTimeout {
+			close(unblock)
+			t.Errorf("expected 504 when ctx is cancelled before commit, got %d", resp.StatusCode)
+			return
+		}
+		close(unblock) // let the handler goroutine unwind
+		_ = resp.Body.Close()
+	case <-time.After(2 * time.Second):
+		close(unblock)
+		t.Error("executePluginHandler did not return after ctx cancellation before commit")
+	}
+}
+
+func TestExecutePluginHandler_PanicBeforeWrite(t *testing.T) {
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("boom")
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/", http.NoBody)
+	resp := executePluginHandler(context.Background(), logging.NoOp, "", handler, req)
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("expected 502 on panic before any write, got %d", resp.StatusCode)
+		return
+	}
+	_, err := io.ReadAll(resp.Body)
+	if err == nil || !strings.Contains(err.Error(), "client plugin handler panicked") {
+		t.Errorf("expected panic surfaced as body error, got %v", err)
+		return
+	}
+	_ = resp.Body.Close()
+}
+
+func TestExecutePluginHandler_PanicAfterPartialWrite(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		if _, err := io.WriteString(w, "partial"); err != nil {
+			t.Errorf("write partial: %v", err)
+			return
+		}
+		panic("boom")
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/", http.NoBody)
+	resp := executePluginHandler(context.Background(), logging.NoOp, "", handler, req)
+
+	if resp.StatusCode != http.StatusTeapot {
+		t.Errorf("expected committed status 418 preserved across panic, got %d", resp.StatusCode)
+		return
+	}
+	body, err := io.ReadAll(resp.Body)
+	if !strings.HasPrefix(string(body), "partial") {
+		t.Errorf("expected partial body before panic, got %q", string(body))
+		return
+	}
+	if err == nil || !strings.Contains(err.Error(), "client plugin handler panicked") {
+		t.Errorf("expected panic surfaced as body error after partial body, got %v", err)
+		return
+	}
+	_ = resp.Body.Close()
+}

--- a/transport/http/client/status.go
+++ b/transport/http/client/status.go
@@ -140,11 +140,18 @@ func DetailedHTTPStatusHandlerWithErrPrefix(name, errPrefix string) HTTPStatusHa
 	}
 }
 
+// maxErrorResponseBody bounds how much of an error response body is read into the error
+// message. It is large enough not to truncate real error payloads but prevents an unbounded
+// or still-streaming error body (e.g. from a client plugin) from being buffered without limit.
+// It is a var rather than a const so tests can lower it without allocating the full cap.
+var maxErrorResponseBody int64 = 8 << 20 // 8 MiB
+
 func newHTTPResponseError(resp *http.Response) HTTPResponseError {
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		body = []byte{}
-	}
+	// io.ReadAll returns the bytes read before any error, so keep them rather than
+	// discarding a partial payload. A body over maxErrorResponseBody is silently truncated
+	// (LimitReader yields io.EOF, not an error): the cap bounds the read without surfacing
+	// the truncation as a failure.
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorResponseBody))
 	resp.Body.Close()
 	resp.Body = io.NopCloser(bytes.NewBuffer(body))
 

--- a/transport/http/client/status_test.go
+++ b/transport/http/client/status_test.go
@@ -132,6 +132,39 @@ func TestDefaultHTTPStatusHandler(t *testing.T) {
 	}
 }
 
+func TestNewHTTPResponseError_limitsBodySize(t *testing.T) {
+	original := maxErrorResponseBody
+	defer func() { maxErrorResponseBody = original }()
+	maxErrorResponseBody = 8
+
+	full := "0123456789abcdef" // 16 bytes, over the 8-byte cap
+	resp := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Header:     http.Header{"Content-Type": []string{"text/plain"}},
+		Body:       io.NopCloser(strings.NewReader(full)),
+	}
+
+	respErr := newHTTPResponseError(resp)
+
+	want := full[:maxErrorResponseBody]
+	if respErr.Msg != want {
+		t.Errorf("expected the error message truncated to %q, got %q", want, respErr.Msg)
+		return
+	}
+	if respErr.Enc != "text/plain" {
+		t.Errorf("expected the content type preserved, got %q", respErr.Enc)
+		return
+	}
+	rest, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("re-reading the replaced body: %v", err)
+		return
+	}
+	if string(rest) != want {
+		t.Errorf("expected the replaced body to hold the truncated bytes %q, got %q", want, string(rest))
+	}
+}
+
 var statusCodes = []int{
 	http.StatusBadRequest,
 	http.StatusUnauthorized,


### PR DESCRIPTION
The client plugin executor buffered the entire plugin response with httptest.NewRecorder and only returned once ServeHTTP completed, which makes streaming responses (Server-Sent Events, chunked passthrough, large downloads) impossible: the proxy, and therefore the client, received nothing until the plugin handler returned, i.e. until the upstream stream closed.

Run the handler in a goroutine writing into an io.Pipe and return the response as soon as the status line and headers are known, with the pipe's read end as the body. Bytes now flow to the caller as the handler produces them.

The pipe is unbuffered, so the executor watches the request context and closes the read end on cancellation, ensuring the handler goroutine unwinds even when a consumer drops the response. Flush commits the headers like net/http, a panicking handler surfaces as a 502, and the error-status handler bounds how much of a streaming error body it reads.