### PR TITLE
feat: add QUERY method support

### DIFF
--- a/router/chi/router.go
+++ b/router/chi/router.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
-	Package chi provides some basic implementations for building routers based on go-chi/chi
+Package chi provides some basic implementations for building routers based on go-chi/chi
 */
 package chi
 
@@ -20,10 +20,16 @@ import (
 	"github.com/luraproject/lura/v2/transport/http/server"
 )
 
-// ChiDefaultDebugPattern is the default pattern used to define the debug endpoint
-const ChiDefaultDebugPattern = "/__debug/"
+const (
+	// ChiDefaultDebugPattern is the default pattern used to define the debug endpoint
+	ChiDefaultDebugPattern = "/__debug/"
+	logPrefix              = "[SERVICE: Chi]"
+	methodQuery            = "QUERY"
+)
 
-const logPrefix = "[SERVICE: Chi]"
+func init() {
+	chi.RegisterMethod(methodQuery)
+}
 
 // RunServerFunc is a func that will run the http Server with the given params.
 type RunServerFunc func(context.Context, config.ServiceConfig, http.Handler) error
@@ -115,6 +121,7 @@ func (r chiRouter) registerDebugEndpoints() {
 	r.cfg.Engine.Put(r.cfg.DebugPattern, debugHandler)
 	r.cfg.Engine.Patch(r.cfg.DebugPattern, debugHandler)
 	r.cfg.Engine.Delete(r.cfg.DebugPattern, debugHandler)
+	r.cfg.Engine.Method(methodQuery, r.cfg.DebugPattern, debugHandler)
 }
 
 func (r chiRouter) registerKrakendEndpoints(endpoints []*config.EndpointConfig) {
@@ -151,6 +158,8 @@ func (r chiRouter) registerKrakendEndpoint(method string, endpoint *config.Endpo
 		r.cfg.Engine.Patch(path, handler)
 	case http.MethodDelete:
 		r.cfg.Engine.Delete(path, handler)
+	case methodQuery:
+		r.cfg.Engine.Method(methodQuery, path, handler)
 	default:
 		r.cfg.Logger.Error(logPrefix, "Unsupported method", method)
 		return

--- a/router/chi/router_test.go
+++ b/router/chi/router_test.go
@@ -92,6 +92,14 @@ func TestDefaultFactory_ok(t *testing.T) {
 					{},
 				},
 			},
+			{
+				Endpoint: "/query",
+				Method:   "QUERY",
+				Timeout:  10,
+				Backend: []*config.Backend{
+					{},
+				},
+			},
 		},
 	}
 

--- a/router/gin/router.go
+++ b/router/gin/router.go
@@ -22,7 +22,10 @@ import (
 	"github.com/luraproject/lura/v2/transport/http/server"
 )
 
-const logPrefix = "[SERVICE: Gin]"
+const (
+	logPrefix   = "[SERVICE: Gin]"
+	methodQuery = "QUERY"
+)
 
 // RunServerFunc is a func that will run the http Server with the given params.
 type RunServerFunc func(context.Context, config.ServiceConfig, http.Handler) error
@@ -170,6 +173,8 @@ func (r ginRouter) registerKrakendEndpoint(rg *gin.RouterGroup, method string, e
 		rg.PATCH(path, h)
 	case http.MethodDelete:
 		rg.DELETE(path, h)
+	case methodQuery:
+		rg.Handle(methodQuery, path, h)
 	default:
 		r.cfg.Logger.Error(logPrefix, "[ENDPOINT:", path, "] Unsupported method", method)
 		return

--- a/router/gin/router_test.go
+++ b/router/gin/router_test.go
@@ -84,6 +84,14 @@ func TestDefaultFactory_ok(t *testing.T) {
 					{},
 				},
 			},
+			{
+				Endpoint: "/some",
+				Method:   "QUERY",
+				Timeout:  10,
+				Backend: []*config.Backend{
+					{},
+				},
+			},
 		},
 		ExtraConfig: map[string]interface{}{
 			Namespace: map[string]interface{}{
@@ -140,7 +148,7 @@ func TestDefaultFactory_ok(t *testing.T) {
 		return
 	}
 
-	if allow := resp.Header.Get("Allow"); allow != "DELETE, GET, PATCH, POST, PUT" {
+	if allow := resp.Header.Get("Allow"); allow != "DELETE, GET, PATCH, POST, PUT, QUERY" {
 		t.Errorf("unexpected options response: '%s'", allow)
 	}
 }

--- a/router/gorilla/router_test.go
+++ b/router/gorilla/router_test.go
@@ -80,6 +80,14 @@ func TestDefaultFactory_ok(t *testing.T) {
 					{},
 				},
 			},
+			{
+				Endpoint: "/query",
+				Method:   "QUERY",
+				Timeout:  10,
+				Backend: []*config.Backend{
+					{},
+				},
+			},
 		},
 	}
 

--- a/router/httptreemux/router_test.go
+++ b/router/httptreemux/router_test.go
@@ -80,6 +80,14 @@ func TestDefaultFactory_ok(t *testing.T) {
 					{},
 				},
 			},
+			{
+				Endpoint: "/query",
+				Method:   "QUERY",
+				Timeout:  10,
+				Backend: []*config.Backend{
+					{},
+				},
+			},
 		},
 	}
 

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -22,6 +22,7 @@ const (
 	DefaultDebugPattern = "/__debug/"
 	DefaultEchoPattern  = "/__echo/"
 	logPrefix           = "[SERVICE: Mux]"
+	methodQuery         = "QUERY"
 )
 
 // RunServerFunc is a func that will run the http Server with the given params.
@@ -104,6 +105,7 @@ func (r httpRouter) Run(cfg config.ServiceConfig) {
 			http.MethodPut,
 			http.MethodPatch,
 			http.MethodDelete,
+			methodQuery,
 			http.MethodHead,
 			http.MethodOptions,
 			http.MethodConnect,
@@ -121,6 +123,7 @@ func (r httpRouter) Run(cfg config.ServiceConfig) {
 			http.MethodPut,
 			http.MethodPatch,
 			http.MethodDelete,
+			methodQuery,
 			http.MethodHead,
 			http.MethodOptions,
 			http.MethodConnect,
@@ -171,6 +174,7 @@ func (r httpRouter) registerKrakendEndpoint(method string, endpoint *config.Endp
 	case http.MethodPut:
 	case http.MethodPatch:
 	case http.MethodDelete:
+	case methodQuery:
 	default:
 		r.cfg.Logger.Error(logPrefix, "Unsupported method", method)
 		return

--- a/router/mux/router_test.go
+++ b/router/mux/router_test.go
@@ -91,6 +91,14 @@ func TestDefaultFactory_ok(t *testing.T) {
 					{},
 				},
 			},
+			{
+				Endpoint: "/query",
+				Method:   "QUERY",
+				Timeout:  10,
+				Backend: []*config.Backend{
+					{},
+				},
+			},
 		},
 	}
 

--- a/router/negroni/router_test.go
+++ b/router/negroni/router_test.go
@@ -82,6 +82,14 @@ func TestDefaultFactory_ok(t *testing.T) {
 					{},
 				},
 			},
+			{
+				Endpoint: "/query",
+				Method:   "QUERY",
+				Timeout:  10,
+				Backend: []*config.Backend{
+					{},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
### Summary

Adds router support for the HTTP `QUERY` method from RFC 10008.

This keeps the scope intentionally small: endpoint registration support for Lura router adapters, with focused coverage in the existing router tests. It also helps unblock downstream gateway support requested in krakend/krakend-ce#1098.

### Changes

- accept `QUERY` endpoints in Gin, Mux, and Chi router registration
- register `QUERY` with go-chi before using it as a custom method
- include `QUERY` in Mux debug/echo method registration
- add focused `QUERY` coverage for Gin, Mux, Chi, Gorilla, HttpTreeMux, and Negroni router factories

### Non-goals

- no `Accept-Query` utilities
- no cache, retry, rate-limit, circuit-breaker, or idempotency behavior changes
- no downstream KrakenD CE dependency bump

### Tests

- `go test ./router/gin -run TestDefaultFactory_ok`
- `go test ./router/mux -run TestDefaultFactory_ok`
- `go test ./router/chi -run TestDefaultFactory_ok`
- `go test ./router/gorilla -run TestDefaultFactory_ok`
- `go test ./router/httptreemux -run TestDefaultFactory_ok`
- `go test ./router/negroni -run TestDefaultFactory_ok`
- `go test -race ./router/...`
- `go test -race ./...`

Note: full non-race router package runs expose existing `TestDefaultFactory_ko` failures around multi-backend non-GET endpoints; I left that behavior untouched because it is unrelated to `QUERY` support and the project test target uses race mode for `./...`.