### PR TITLE
feat: configurable HTTP connection leasing strategy (lifo/fifo)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -156,6 +156,18 @@ type ServiceConfig struct {
 	// that do not support keep-alives ignore this field.
 	DialerKeepAlive time.Duration `mapstructure:"dialer_keep_alive"`
 
+	// ConnectionLeaseStrategy selects how idle backend connections are reused:
+	// "lifo" (the Go net/http default: most-recently-used connection first) or
+	// "fifo" (requests are round-robined across independent connection pools so
+	// idle connections are cycled evenly and traffic is distributed across
+	// backend nodes). An empty value defaults to "lifo".
+	ConnectionLeaseStrategy string `mapstructure:"connection_lease_strategy"`
+	// ConnectionPools is the number of independent connection pools the "fifo"
+	// leasing strategy round-robins across. It is the distribution fan-out, NOT
+	// the idle-connection count: the max_idle_connections* limits are split
+	// across these pools. Ignored for "lifo". A value <= 1 uses a default.
+	ConnectionPools int `mapstructure:"connection_pools"`
+
 	// DisableStrictREST flags if the REST enforcement is disabled
 	DisableStrictREST bool `mapstructure:"disable_rest"`
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -211,7 +211,7 @@ func TestConfig_init(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	if hash != "/X+fgDf29kmtPpCUh9DeJBOwewpExy3IGEjeqA9zExA=" {
+	if hash != "+LjDbM1wmEZFSXXFMoYfTVPNzklc+KRTORh8eG7mMYk=" {
 		t.Errorf("unexpected hash: %s", hash)
 	}
 }

--- a/config/parser.go
+++ b/config/parser.go
@@ -132,75 +132,79 @@ func (p *ParseError) Error() string {
 type FileReaderFunc func(string) ([]byte, error)
 
 type parseableServiceConfig struct {
-	Name                  string                     `json:"name"`
-	Endpoints             []*parseableEndpointConfig `json:"endpoints"`
-	AsyncAgents           []*parseableAsyncAgent     `json:"async_agent"`
-	Timeout               string                     `json:"timeout"`
-	CacheTTL              string                     `json:"cache_ttl"`
-	Host                  []string                   `json:"host"`
-	Port                  int                        `json:"port"`
-	Address               string                     `json:"listen_ip"`
-	Version               int                        `json:"version"`
-	ExtraConfig           *ExtraConfig               `json:"extra_config,omitempty"`
-	ReadTimeout           string                     `json:"read_timeout"`
-	WriteTimeout          string                     `json:"write_timeout"`
-	IdleTimeout           string                     `json:"idle_timeout"`
-	ReadHeaderTimeout     string                     `json:"read_header_timeout"`
-	MaxHeaderBytes        int                        `json:"max_header_bytes"`
-	DisableKeepAlives     bool                       `json:"disable_keep_alives"`
-	DisableCompression    bool                       `json:"disable_compression"`
-	DisableStrictREST     bool                       `json:"disable_rest"`
-	MaxIdleConns          int                        `json:"max_idle_connections"`
-	MaxIdleConnsPerHost   int                        `json:"max_idle_connections_per_host"`
-	IdleConnTimeout       string                     `json:"idle_connection_timeout"`
-	ResponseHeaderTimeout string                     `json:"response_header_timeout"`
-	ExpectContinueTimeout string                     `json:"expect_continue_timeout"`
-	OutputEncoding        string                     `json:"output_encoding"`
-	DialerTimeout         string                     `json:"dialer_timeout"`
-	DialerFallbackDelay   string                     `json:"dialer_fallback_delay"`
-	DialerKeepAlive       string                     `json:"dialer_keep_alive"`
-	Debug                 bool                       `json:"debug_endpoint"`
-	Echo                  bool                       `json:"echo_endpoint"`
-	Plugin                *Plugin                    `json:"plugin,omitempty"`
-	TLS                   *parseableTLS              `json:"tls,omitempty"`
-	ClientTLS             *parseableClientTLS        `json:"client_tls,omitempty"`
-	UseH2C                bool                       `json:"use_h2c,omitempty"`
-	DNSCacheTTL           string                     `json:"dns_cache_ttl"`
-	MaxShutdownDuration   string                     `json:"max_shutdown_wait_time"`
+	Name                    string                     `json:"name"`
+	Endpoints               []*parseableEndpointConfig `json:"endpoints"`
+	AsyncAgents             []*parseableAsyncAgent     `json:"async_agent"`
+	Timeout                 string                     `json:"timeout"`
+	CacheTTL                string                     `json:"cache_ttl"`
+	Host                    []string                   `json:"host"`
+	Port                    int                        `json:"port"`
+	Address                 string                     `json:"listen_ip"`
+	Version                 int                        `json:"version"`
+	ExtraConfig             *ExtraConfig               `json:"extra_config,omitempty"`
+	ReadTimeout             string                     `json:"read_timeout"`
+	WriteTimeout            string                     `json:"write_timeout"`
+	IdleTimeout             string                     `json:"idle_timeout"`
+	ReadHeaderTimeout       string                     `json:"read_header_timeout"`
+	MaxHeaderBytes          int                        `json:"max_header_bytes"`
+	DisableKeepAlives       bool                       `json:"disable_keep_alives"`
+	DisableCompression      bool                       `json:"disable_compression"`
+	DisableStrictREST       bool                       `json:"disable_rest"`
+	MaxIdleConns            int                        `json:"max_idle_connections"`
+	MaxIdleConnsPerHost     int                        `json:"max_idle_connections_per_host"`
+	IdleConnTimeout         string                     `json:"idle_connection_timeout"`
+	ResponseHeaderTimeout   string                     `json:"response_header_timeout"`
+	ExpectContinueTimeout   string                     `json:"expect_continue_timeout"`
+	OutputEncoding          string                     `json:"output_encoding"`
+	DialerTimeout           string                     `json:"dialer_timeout"`
+	DialerFallbackDelay     string                     `json:"dialer_fallback_delay"`
+	DialerKeepAlive         string                     `json:"dialer_keep_alive"`
+	ConnectionLeaseStrategy string                     `json:"connection_lease_strategy"`
+	ConnectionPools         int                        `json:"connection_pools"`
+	Debug                   bool                       `json:"debug_endpoint"`
+	Echo                    bool                       `json:"echo_endpoint"`
+	Plugin                  *Plugin                    `json:"plugin,omitempty"`
+	TLS                     *parseableTLS              `json:"tls,omitempty"`
+	ClientTLS               *parseableClientTLS        `json:"client_tls,omitempty"`
+	UseH2C                  bool                       `json:"use_h2c,omitempty"`
+	DNSCacheTTL             string                     `json:"dns_cache_ttl"`
+	MaxShutdownDuration     string                     `json:"max_shutdown_wait_time"`
 }
 
 func (p *parseableServiceConfig) normalize() ServiceConfig {
 	cfg := ServiceConfig{
-		Name:                  p.Name,
-		Timeout:               parseDuration(p.Timeout),
-		CacheTTL:              parseDuration(p.CacheTTL),
-		Host:                  p.Host,
-		Port:                  p.Port,
-		Address:               p.Address,
-		Version:               p.Version,
-		Debug:                 p.Debug,
-		Echo:                  p.Echo,
-		ReadTimeout:           parseDuration(p.ReadTimeout),
-		WriteTimeout:          parseDuration(p.WriteTimeout),
-		IdleTimeout:           parseDuration(p.IdleTimeout),
-		ReadHeaderTimeout:     parseDuration(p.ReadHeaderTimeout),
-		MaxHeaderBytes:        p.MaxHeaderBytes,
-		DisableKeepAlives:     p.DisableKeepAlives,
-		DisableCompression:    p.DisableCompression,
-		DisableStrictREST:     p.DisableStrictREST,
-		MaxIdleConns:          p.MaxIdleConns,
-		MaxIdleConnsPerHost:   p.MaxIdleConnsPerHost,
-		IdleConnTimeout:       parseDuration(p.IdleConnTimeout),
-		ResponseHeaderTimeout: parseDuration(p.ResponseHeaderTimeout),
-		ExpectContinueTimeout: parseDuration(p.ExpectContinueTimeout),
-		DialerTimeout:         parseDuration(p.DialerTimeout),
-		DialerFallbackDelay:   parseDuration(p.DialerFallbackDelay),
-		DialerKeepAlive:       parseDuration(p.DialerKeepAlive),
-		OutputEncoding:        p.OutputEncoding,
-		Plugin:                p.Plugin,
-		UseH2C:                p.UseH2C,
-		DNSCacheTTL:           parseDuration(p.DNSCacheTTL),
-		MaxShutdownDuration:   parseDuration(p.MaxShutdownDuration),
+		Name:                    p.Name,
+		Timeout:                 parseDuration(p.Timeout),
+		CacheTTL:                parseDuration(p.CacheTTL),
+		Host:                    p.Host,
+		Port:                    p.Port,
+		Address:                 p.Address,
+		Version:                 p.Version,
+		Debug:                   p.Debug,
+		Echo:                    p.Echo,
+		ReadTimeout:             parseDuration(p.ReadTimeout),
+		WriteTimeout:            parseDuration(p.WriteTimeout),
+		IdleTimeout:             parseDuration(p.IdleTimeout),
+		ReadHeaderTimeout:       parseDuration(p.ReadHeaderTimeout),
+		MaxHeaderBytes:          p.MaxHeaderBytes,
+		DisableKeepAlives:       p.DisableKeepAlives,
+		DisableCompression:      p.DisableCompression,
+		DisableStrictREST:       p.DisableStrictREST,
+		MaxIdleConns:            p.MaxIdleConns,
+		MaxIdleConnsPerHost:     p.MaxIdleConnsPerHost,
+		IdleConnTimeout:         parseDuration(p.IdleConnTimeout),
+		ResponseHeaderTimeout:   parseDuration(p.ResponseHeaderTimeout),
+		ExpectContinueTimeout:   parseDuration(p.ExpectContinueTimeout),
+		DialerTimeout:           parseDuration(p.DialerTimeout),
+		DialerFallbackDelay:     parseDuration(p.DialerFallbackDelay),
+		DialerKeepAlive:         parseDuration(p.DialerKeepAlive),
+		ConnectionLeaseStrategy: p.ConnectionLeaseStrategy,
+		ConnectionPools:         p.ConnectionPools,
+		OutputEncoding:          p.OutputEncoding,
+		Plugin:                  p.Plugin,
+		UseH2C:                  p.UseH2C,
+		DNSCacheTTL:             parseDuration(p.DNSCacheTTL),
+		MaxShutdownDuration:     parseDuration(p.MaxShutdownDuration),
 	}
 	if p.TLS != nil {
 		cfg.TLS = &TLS{

--- a/transport/http/server/connection_pool.go
+++ b/transport/http/server/connection_pool.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+
+	"github.com/luraproject/lura/v2/config"
+	"github.com/luraproject/lura/v2/logging"
+)
+
+const (
+	// leaseStrategyLIFO is the Go net/http default: the most-recently-used idle
+	// connection is reused first (stack). It is the behaviour when the strategy
+	// is unset, so the plain transport is used for it.
+	leaseStrategyLIFO = "lifo"
+	// leaseStrategyFIFO round-robins requests across a ring of independent
+	// transports so idle connections are cycled evenly and traffic is spread
+	// across backend nodes (queue-like behaviour). Go's stdlib transport cannot
+	// do FIFO within a single idle pool, so we round-robin over N pools to obtain
+	// the even-distribution benefits.
+	leaseStrategyFIFO = "fifo"
+
+	// defaultConnectionPools is the ring size used by the "fifo" strategy when
+	// ConnectionPools is not set. Eight suits a handful of backend replicas while
+	// keeping strong keep-alive reuse under the default max_idle_connections_per_host.
+	defaultConnectionPools = 8
+	// maxConnectionPools is an upper safety clamp so a mistyped config cannot
+	// spawn an unreasonable number of transports/sockets.
+	maxConnectionPools = 256
+)
+
+// newDefaultTransport builds the RoundTripper installed as http.DefaultTransport
+// from the service config. For the default "lifo" strategy it returns the plain
+// stdlib transport; for "fifo" it returns a round-robin ring of independent
+// transports cloned from it.
+func newDefaultTransport(cfg config.ServiceConfig, logger logging.Logger) http.RoundTripper {
+	base := NewTransport(cfg, logger)
+
+	switch strings.ToLower(strings.TrimSpace(cfg.ConnectionLeaseStrategy)) {
+	case "", leaseStrategyLIFO:
+		return base
+	case leaseStrategyFIFO:
+		// handled below
+	default:
+		logger.Warning(fmt.Sprintf("%s unknown connection_lease_strategy %q, falling back to lifo",
+			loggerPrefix, cfg.ConnectionLeaseStrategy))
+		return base
+	}
+
+	size := cfg.ConnectionPools
+	if size <= 1 {
+		size = defaultConnectionPools
+	}
+	if size > maxConnectionPools {
+		logger.Warning(fmt.Sprintf("%s connection_pools %d exceeds the maximum %d, clamping",
+			loggerPrefix, size, maxConnectionPools))
+		size = maxConnectionPools
+	}
+	// A ring wider than the per-host idle cap starves each pool of keep-alive
+	// reuse (every pool holds a single idle connection and re-dials per request).
+	if base.MaxIdleConnsPerHost > 0 && size > base.MaxIdleConnsPerHost {
+		logger.Warning(fmt.Sprintf("%s connection_pools %d exceeds max_idle_connections_per_host %d; each pool keeps a single idle connection, reducing keep-alive reuse",
+			loggerPrefix, size, base.MaxIdleConnsPerHost))
+	}
+
+	ring := make([]*http.Transport, size)
+	for i := range ring {
+		t := base.Clone()
+		// Keep the aggregate idle-pool capacity roughly aligned with the
+		// configured limits by splitting them across the ring. A value of 0
+		// means "unlimited" in net/http, so it is left untouched.
+		if base.MaxIdleConns > 0 {
+			t.MaxIdleConns = ceilDiv(base.MaxIdleConns, size)
+		}
+		if base.MaxIdleConnsPerHost > 0 {
+			t.MaxIdleConnsPerHost = ceilDiv(base.MaxIdleConnsPerHost, size)
+		}
+		ring[i] = t
+	}
+
+	logger.Debug(fmt.Sprintf("%s FIFO connection leasing enabled (ring of %d transports)", loggerPrefix, size))
+	return newRoundRobinTransport(ring)
+}
+
+// ceilDiv returns ceil(a/b) with a floor of 1, guarding against a zero divisor.
+func ceilDiv(a, b int) int {
+	if b <= 0 {
+		return a
+	}
+	r := a / b
+	if a%b != 0 {
+		r++
+	}
+	if r < 1 {
+		r = 1
+	}
+	return r
+}
+
+// roundRobinTransport dispatches each request to the next transport in the ring
+// using an atomic counter. Each transport keeps its own idle-connection pool, so
+// spreading requests across the ring cycles connections evenly and distributes
+// traffic across backend nodes instead of always reusing the warmest connection.
+type roundRobinTransport struct {
+	transports []*http.Transport
+	counter    uint64
+}
+
+func newRoundRobinTransport(transports []*http.Transport) *roundRobinTransport {
+	return &roundRobinTransport{transports: transports}
+}
+
+// pick returns the next transport in the ring.
+func (rr *roundRobinTransport) pick() *http.Transport {
+	n := atomic.AddUint64(&rr.counter, 1) - 1
+	return rr.transports[int(n%uint64(len(rr.transports)))]
+}
+
+// RoundTrip implements http.RoundTripper.
+func (rr *roundRobinTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return rr.pick().RoundTrip(req)
+}
+
+// CloseIdleConnections closes idle connections on every transport in the ring so
+// the ring honours the http.Client.CloseIdleConnections contract.
+func (rr *roundRobinTransport) CloseIdleConnections() {
+	for _, t := range rr.transports {
+		t.CloseIdleConnections()
+	}
+}

--- a/transport/http/server/connection_pool_test.go
+++ b/transport/http/server/connection_pool_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/luraproject/lura/v2/config"
+	"github.com/luraproject/lura/v2/logging"
+)
+
+func TestNewDefaultTransport_LIFO(t *testing.T) {
+	for _, strat := range []string{"", "lifo", "LIFO", " Lifo "} {
+		rt := newDefaultTransport(config.ServiceConfig{ConnectionLeaseStrategy: strat}, logging.NoOp)
+		if _, ok := rt.(*http.Transport); !ok {
+			t.Errorf("strategy %q: expected plain *http.Transport, got %T", strat, rt)
+		}
+	}
+}
+
+func TestNewDefaultTransport_UnknownFallsBackToLIFO(t *testing.T) {
+	rt := newDefaultTransport(config.ServiceConfig{ConnectionLeaseStrategy: "bogus"}, logging.NoOp)
+	if _, ok := rt.(*http.Transport); !ok {
+		t.Fatalf("expected plain *http.Transport for unknown strategy, got %T", rt)
+	}
+}
+
+func TestNewDefaultTransport_FIFO(t *testing.T) {
+	cfg := config.ServiceConfig{
+		ConnectionLeaseStrategy: "fifo",
+		ConnectionPools:         4,
+		MaxIdleConns:            400,
+		MaxIdleConnsPerHost:     100,
+	}
+	rt := newDefaultTransport(cfg, logging.NoOp)
+	rr, ok := rt.(*roundRobinTransport)
+	if !ok {
+		t.Fatalf("expected *roundRobinTransport, got %T", rt)
+	}
+	if len(rr.transports) != 4 {
+		t.Fatalf("ring size = %d, want 4", len(rr.transports))
+	}
+	for i, tr := range rr.transports {
+		if tr.MaxIdleConns != 100 { // 400 / 4
+			t.Errorf("pool %d MaxIdleConns = %d, want 100", i, tr.MaxIdleConns)
+		}
+		if tr.MaxIdleConnsPerHost != 25 { // 100 / 4
+			t.Errorf("pool %d MaxIdleConnsPerHost = %d, want 25", i, tr.MaxIdleConnsPerHost)
+		}
+	}
+}
+
+func TestNewDefaultTransport_FIFODefaultsAndClamp(t *testing.T) {
+	// pools <= 1 uses the default ring size.
+	rt := newDefaultTransport(config.ServiceConfig{ConnectionLeaseStrategy: "fifo"}, logging.NoOp)
+	if rr := rt.(*roundRobinTransport); len(rr.transports) != defaultConnectionPools {
+		t.Errorf("default ring size = %d, want %d", len(rr.transports), defaultConnectionPools)
+	}
+	// oversized pools are clamped.
+	rt = newDefaultTransport(config.ServiceConfig{ConnectionLeaseStrategy: "fifo", ConnectionPools: 10000}, logging.NoOp)
+	if rr := rt.(*roundRobinTransport); len(rr.transports) != maxConnectionPools {
+		t.Errorf("clamped ring size = %d, want %d", len(rr.transports), maxConnectionPools)
+	}
+}
+
+func TestRoundRobinTransportRotates(t *testing.T) {
+	const size = 3
+	ring := make([]*http.Transport, size)
+	for i := range ring {
+		ring[i] = &http.Transport{}
+	}
+	rr := newRoundRobinTransport(ring)
+
+	seen := make([]*http.Transport, 2*size)
+	for i := range seen {
+		seen[i] = rr.pick()
+	}
+	for i := 0; i < size; i++ {
+		if seen[i] != seen[i+size] {
+			t.Errorf("pick %d and %d differ; expected round-robin", i, i+size)
+		}
+	}
+	if seen[0] == seen[1] || seen[1] == seen[2] || seen[0] == seen[2] {
+		t.Errorf("expected %d distinct transports in the ring", size)
+	}
+}
+
+func TestCeilDiv(t *testing.T) {
+	cases := map[string][3]int{ // a, b -> want
+		"exact":    {400, 4, 100},
+		"round up": {250, 8, 32},
+		"floor 1":  {3, 8, 1},
+		"zero b":   {250, 0, 250},
+	}
+	for name, c := range cases {
+		if got := ceilDiv(c[0], c[1]); got != c[2] {
+			t.Errorf("%s: ceilDiv(%d,%d) = %d, want %d", name, c[0], c[1], got, c[2])
+		}
+	}
+}

--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -75,7 +75,7 @@ func InitHTTPDefaultTransportWithLogger(cfg config.ServiceConfig, logger logging
 		cfg.ClientTLS.AllowInsecureConnections = true
 	}
 	onceTransportConfig.Do(func() {
-		http.DefaultTransport = NewTransport(cfg, logger)
+		http.DefaultTransport = newDefaultTransport(cfg, logger)
 	})
 }
 


### PR DESCRIPTION
## Problem

The outbound backend connection pool is Go's standard-library `http.Transport` (`http.DefaultTransport`, built by `NewTransport`), whose idle-connection reuse is **hardcoded LIFO** — it always reuses the most-recently-used connection. Behind an L4 load balancer this tends to **hot-spot traffic on a subset of backend nodes** and can keep cold connections alive indefinitely. Go's stdlib exposes no knob for this, and lura currently only exposes pool *sizes*/*timeouts* (`max_idle_connections*`, `idle_connection_timeout`, ...).

This is the same trade-off Reactor Netty / Spring Cloud Gateway expose via `ConnectionProvider.LeasingStrategy` (`FIFO`/`LIFO`).

## What this adds

Two service-level settings:

```json
{
  "connection_lease_strategy": "fifo",
  "connection_pools": 8
}
```

- `connection_lease_strategy`: `"lifo"` (default) or `"fifo"`.
- `connection_pools`: number of independent pools the `"fifo"` strategy round-robins across (distribution fan-out, **not** the idle-connection count). Defaults to `8`, clamped to `256`, warns when it exceeds `max_idle_connections_per_host`.

Since a single stdlib transport cannot do FIFO, `"fifo"` clones the configured transport into N independent pools (the `max_idle_connections*` limits are split across them to keep aggregate capacity aligned) and installs a round-robin `RoundTripper` — cycling idle connections evenly and distributing traffic across backend nodes.

## Behaviour / back-compat

- Default and `"lifo"` return the plain `*http.Transport` — **current behaviour is unchanged**.
- Only `InitHTTPDefaultTransport(WithLogger)` changes: it now calls a small `newDefaultTransport` helper. `NewTransport` keeps its exact signature and is reused as the per-pool builder.
- `ServiceConfig` gains two fields (with `mapstructure`/`json` tags); `ServiceConfig.Hash()` changes accordingly, so the golden hash in `config_test.go` was updated.

## Implementation

- `config/config.go`, `config/parser.go`: two new fields + parsing.
- `transport/http/server/connection_pool.go` (new): `newDefaultTransport`, the `roundRobinTransport`, and `ceilDiv`.
- `transport/http/server/server.go`: one-line wiring in `InitHTTPDefaultTransportWithLogger`.

## Tests

New unit tests cover strategy selection (lifo/fifo/unknown), default + clamp handling, idle-limit splitting, and ring rotation. `gofmt`, `go vet ./...`, `go build ./...`, and `go test ./config/ ./transport/http/server/` all pass.

## Notes

The `"fifo"` strategy is a round-robin over N pools rather than a strict single-pool oldest-first queue (Go's transport can't express the latter); it targets the practical goal — even connection cycling and load distribution across backend nodes.