### PR TITLE
router/gin: return HTTP 499 for context.Canceled (client closed request)

### DIFF
--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -4,6 +4,7 @@ package gin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/textproto"
 
@@ -99,13 +100,21 @@ func CustomErrorEndpointHandler(logger logging.Logger, errF server.ToHTTPError) 
 							}
 						}
 					}
-					if t, ok := err.(responseError); ok {
+					// 499 Client Closed Request — mirrors the nginx convention for client
+					// aborts. errors.Is is used so wrapped context.Canceled values
+					// (e.g. fmt.Errorf("...: %w", context.Canceled)) are also caught.
+					// context.DeadlineExceeded is intentionally excluded: server-side
+					// timeouts remain 500.
+					clientCanceled := errors.Is(err, context.Canceled)
+					if clientCanceled {
+						c.Status(499)
+					} else if t, ok := err.(responseError); ok {
 						c.Status(t.StatusCode())
 					} else {
 						c.Status(errF(err))
 					}
-
-					if returnErrorMsg {
+					// Do not write an error body when the client is already gone.
+					if returnErrorMsg && !clientCanceled {
 						ErrorResponseWriter(c, err)
 					}
 					cancel()

--- a/router/gin/endpoint_test.go
+++ b/router/gin/endpoint_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -292,6 +293,94 @@ func TestEndpointHandler_cancel(t *testing.T) {
 		expectedCache:      "",
 		expectedContent:    "application/json; charset=utf-8",
 		expectedStatusCode: http.StatusOK,
+		completed:          false,
+	}.test(t)
+	time.Sleep(5 * time.Millisecond)
+}
+
+func TestEndpointHandler_clientCanceled(t *testing.T) {
+	// Direct context.Canceled → 499.
+	p := func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
+		return nil, context.Canceled
+	}
+	endpointHandlerTestCase{
+		timeout:            time.Minute,
+		proxy:              p,
+		method:             "GET",
+		expectedBody:       "",
+		expectedCache:      "",
+		expectedContent:    "",
+		expectedStatusCode: 499,
+		completed:          false,
+	}.test(t)
+	time.Sleep(5 * time.Millisecond)
+
+	// Wrapped context.Canceled — errors.Is must unwrap it → 499.
+	p2 := func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
+		return nil, fmt.Errorf("upstream closed: %w", context.Canceled)
+	}
+	endpointHandlerTestCase{
+		timeout:            time.Minute,
+		proxy:              p2,
+		method:             "GET",
+		expectedBody:       "",
+		expectedCache:      "",
+		expectedContent:    "",
+		expectedStatusCode: 499,
+		completed:          false,
+	}.test(t)
+	time.Sleep(5 * time.Millisecond)
+
+	// context.DeadlineExceeded must NOT be remapped — server-side timeouts stay 500.
+	p3 := func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
+		return nil, context.DeadlineExceeded
+	}
+	endpointHandlerTestCase{
+		timeout:            time.Minute,
+		proxy:              p3,
+		method:             "GET",
+		expectedBody:       "",
+		expectedCache:      "",
+		expectedContent:    "",
+		expectedStatusCode: http.StatusInternalServerError,
+		completed:          false,
+	}.test(t)
+	time.Sleep(5 * time.Millisecond)
+
+	// Generic error — unchanged baseline, still 500.
+	p4 := func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
+		return nil, errors.New("something went wrong")
+	}
+	endpointHandlerTestCase{
+		timeout:            time.Minute,
+		proxy:              p4,
+		method:             "GET",
+		expectedBody:       "",
+		expectedCache:      "",
+		expectedContent:    "",
+		expectedStatusCode: http.StatusInternalServerError,
+		completed:          false,
+	}.test(t)
+	time.Sleep(5 * time.Millisecond)
+}
+
+func TestEndpointHandler_clientCanceled_noBody(t *testing.T) {
+	// Even when returnErrorMsg is true, no body must be written for a canceled
+	// request — the client is gone and writing would be wasteful.
+	returnErrorMsg = true
+	defer func() { returnErrorMsg = false }()
+
+	p := func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
+		return nil, context.Canceled
+	}
+	endpointHandlerTestCase{
+		timeout:            time.Minute,
+		proxy:              p,
+		method:             "GET",
+		expectedBody:       "",
+		expectedCache:      "",
+		expectedContent:    "",
+		expectedStatusCode: 499,
 		completed:          false,
 	}.test(t)
 	time.Sleep(5 * time.Millisecond)


### PR DESCRIPTION
Closes #807

## Problem

When a client disconnects before KrakenD finishes proxying the upstream response, the Go runtime surfaces the abort as `context.Canceled`. The Gin endpoint handler currently falls through to `errF(err)` (which maps to `server.DefaultToHTTPError`, returning 500 Internal Server Error). This is semantically incorrect: the server did not fail — the client left.

nginx has established 499 (Client Closed Request) as the conventional status code for this case. Every major API gateway and load balancer recognises it.

## What this PR changes

`router/gin/endpoint.go` — inside the `if response == nil` branch of `CustomErrorEndpointHandler`:

1. Adds `"errors"` to the import block (alphabetical, after `"context"`).
2. Checks `errors.Is(err, context.Canceled)` **before** the `responseError` type-assert.
   - If true → `c.Status(499)`.
   - `ErrorResponseWriter` is skipped (client is gone; writing is wasteful and can log spurious errors).
3. All other errors — including `context.DeadlineExceeded` — are **not** affected. Server-side timeouts remain 500.

`errors.Is` is used rather than a direct equality check so that wrapped errors (e.g. `fmt.Errorf("...: %w", context.Canceled)`) are also caught.

## Why `engine.ContextWithFallback = true` matters

Lura sets `engine.ContextWithFallback = true` (`router/gin/engine.go`). This makes Gin propagate the request context's cancellation into `c` itself, so when the client disconnects the underlying `context.Context` is cancelled and the proxy returns `context.Canceled` as a first-class error — not wrapped in a Gin-internal type. The `errors.Is` check is therefore reliable.

## Known limitation: multi-backend endpoints

`proxy.mergeError` (`proxy/merging.go`) wraps upstream errors but does not implement `Unwrap()`, so `errors.Is(err, context.Canceled)` returns `false` for endpoints with more than one backend. Those endpoints will continue to return 500 on client abort until `mergeError` gains `Unwrap()`. Single-backend endpoints (the vast majority) are fully covered.

## Tests added (`router/gin/endpoint_test.go`)

`TestEndpointHandler_clientCanceled`:

| Proxy returns | Expected status |
|---|---|
| `context.Canceled` (direct) | 499 |
| `fmt.Errorf("upstream: %w", context.Canceled)` (wrapped) | 499 |
| `context.DeadlineExceeded` (must not be remapped) | 500 |
| `errors.New("generic")` (baseline) | 500 |

`TestEndpointHandler_clientCanceled_noBody`: verifies that `returnErrorMsg = true` does **not** write a body for a canceled request.

## Verification

```
go build ./router/gin/   # clean
go vet ./router/gin/     # clean
go test ./router/gin/    # all 34 tests pass
```